### PR TITLE
dataporten now use camel case in json keys

### DIFF
--- a/src/main/java/no/sikt/nva/pubchannels/dataporten/DataportenJournal.java
+++ b/src/main/java/no/sikt/nva/pubchannels/dataporten/DataportenJournal.java
@@ -9,13 +9,13 @@ import no.sikt.nva.pubchannels.handler.ScientificValue;
 import no.sikt.nva.pubchannels.handler.ThirdPartyJournal;
 
 final class DataportenJournal implements Immutable, ThirdPartyJournal {
-    private static final String YEAR_FIELD = "Year";
-    private static final String ONLINE_ISSN_FIELD = "Eissn";
-    private static final String IDENTIFIER_FIELD = "Pid";
-    private static final String SCIENTIFIC_VALUE_FIELD = "Level";
-    private static final String PRINT_ISSN_FIELD = "Pissn";
-    private static final String NAME_FIELD = "Name";
-    private static final String HOMEPAGE_FIELD = "KURL";
+    private static final String YEAR_FIELD = "year";
+    private static final String ONLINE_ISSN_FIELD = "eissn";
+    private static final String IDENTIFIER_FIELD = "pid";
+    private static final String SCIENTIFIC_VALUE_FIELD = "level";
+    private static final String PRINT_ISSN_FIELD = "pissn";
+    private static final String NAME_FIELD = "name";
+    private static final String HOMEPAGE_FIELD = "kURL";
 
     @JsonProperty(YEAR_FIELD)
     private final String year;

--- a/src/test/java/no/sikt/nva/pubchannels/handler/DataportenBodyBuilder.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/DataportenBodyBuilder.java
@@ -14,39 +14,39 @@ public class DataportenBodyBuilder {
     }
 
     public DataportenBodyBuilder withPid(String pid) {
-        bodyMap.put("Pid", pid);
+        bodyMap.put("pid", pid);
         return this;
     }
 
     public DataportenBodyBuilder withName(String name) {
-        bodyMap.put("Name", name);
+        bodyMap.put("name", name);
         return this;
     }
 
     public DataportenBodyBuilder withEissn(String eissn) {
-        bodyMap.put("Eissn", eissn);
+        bodyMap.put("eissn", eissn);
         return this;
     }
 
     public DataportenBodyBuilder withPissn(String pissn) {
-        bodyMap.put("Pissn", pissn);
+        bodyMap.put("pissn", pissn);
         return this;
     }
 
     public DataportenBodyBuilder withYear(String year) {
-        bodyMap.put("Year", year);
+        bodyMap.put("year", year);
         return this;
     }
 
     public DataportenBodyBuilder withLevel(String level) {
         if (Objects.nonNull(level)) {
-            bodyMap.put("Level", level);
+            bodyMap.put("level", level);
         }
         return this;
     }
 
     public DataportenBodyBuilder withKurl(String kurl) {
-        bodyMap.put("KURL", kurl);
+        bodyMap.put("kURL", kurl);
         return this;
     }
 


### PR DESCRIPTION
Simple change as new channel registry API switched to camel case json keys.