### PR TITLE
Should return channel id with requested year if third party does not provide year

### DIFF
--- a/src/main/java/no/sikt/nva/pubchannels/dataporten/model/DataportenLevel.java
+++ b/src/main/java/no/sikt/nva/pubchannels/dataporten/model/DataportenLevel.java
@@ -8,12 +8,12 @@ public class DataportenLevel {
     public static final String YEAR_FIELD = "year";
     public static final String LEVEL_FIELD = "level";
     @JsonProperty(YEAR_FIELD)
-    private final int year;
+    private final Integer year;
     @JsonProperty(LEVEL_FIELD)
     private final String level;
 
     @JsonCreator
-    public DataportenLevel(@JsonProperty(YEAR_FIELD) int year, @JsonProperty(LEVEL_FIELD) String level) {
+    public DataportenLevel(@JsonProperty(YEAR_FIELD) Integer year, @JsonProperty(LEVEL_FIELD) String level) {
         this.year = year;
         this.level = level;
     }
@@ -22,7 +22,7 @@ public class DataportenLevel {
         return level;
     }
 
-    public int getYear() {
+    public Integer getYear() {
         return year;
     }
 }

--- a/src/main/java/no/sikt/nva/pubchannels/handler/fetch/journal/FetchByIdAndYearResponse.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/fetch/journal/FetchByIdAndYearResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.net.URI;
 import java.util.Objects;
+import java.util.Optional;
 import no.sikt.nva.pubchannels.handler.ScientificValue;
 import no.sikt.nva.pubchannels.handler.ThirdPartyJournal;
 import no.sikt.nva.pubchannels.model.Contexts;
@@ -53,9 +54,10 @@ public class FetchByIdAndYearResponse {
         this.sameAs = sameAs;
     }
 
-    public static FetchByIdAndYearResponse create(URI selfUriBase, ThirdPartyJournal journal) {
+    public static FetchByIdAndYearResponse create(URI selfUriBase, ThirdPartyJournal journal, String requestedYear) {
+        var year = Optional.ofNullable(journal.getYear()).orElse(requestedYear);
         var id = UriWrapper.fromUri(selfUriBase)
-                     .addChild(journal.getIdentifier(), journal.getYear())
+                     .addChild(journal.getIdentifier(), year)
                      .getUri();
         return new FetchByIdAndYearResponse(id,
                                             journal.getName(),

--- a/src/main/java/no/sikt/nva/pubchannels/handler/fetch/journal/FetchJournalByIdentifierAndYearHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/fetch/journal/FetchJournalByIdentifierAndYearHandler.java
@@ -4,8 +4,8 @@ import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import no.sikt.nva.pubchannels.dataporten.ChannelType;
 import no.sikt.nva.pubchannels.handler.PublicationChannelClient;
-import no.sikt.nva.pubchannels.handler.fetch.FetchByIdentifierAndYearHandler;
 import no.sikt.nva.pubchannels.handler.ThirdPartyJournal;
+import no.sikt.nva.pubchannels.handler.fetch.FetchByIdentifierAndYearHandler;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.BadRequestException;
@@ -37,9 +37,10 @@ public class FetchJournalByIdentifierAndYearHandler extends
 
         var journalIdBaseUri = constructPublicationChannelIdBaseUri(JOURNAL_PATH_ELEMENT);
 
+        var requestYear = request.getYear();
         return FetchByIdAndYearResponse.create(journalIdBaseUri,
                                                (ThirdPartyJournal) publicationChannelClient.getChannel(
                                                    ChannelType.JOURNAL,
-                                                   request.getIdentifier(), request.getYear()));
+                                                   request.getIdentifier(), requestYear), requestYear);
     }
 }

--- a/src/main/java/no/sikt/nva/pubchannels/handler/fetch/publisher/FetchByIdAndYearResponse.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/fetch/publisher/FetchByIdAndYearResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.net.URI;
 import java.util.Objects;
+import java.util.Optional;
 import no.sikt.nva.pubchannels.handler.ScientificValue;
 import no.sikt.nva.pubchannels.handler.ThirdPartyPublisher;
 import no.sikt.nva.pubchannels.model.Contexts;
@@ -48,9 +49,11 @@ public class FetchByIdAndYearResponse {
         this.sameAs = sameAs;
     }
 
-    public static FetchByIdAndYearResponse create(URI selfUriBase, ThirdPartyPublisher publisher) {
+    public static FetchByIdAndYearResponse create(URI selfUriBase, ThirdPartyPublisher publisher,
+                                                  String requestedYear) {
+        var year = Optional.ofNullable(publisher.getYear()).orElse(requestedYear);
         var id = UriWrapper.fromUri(selfUriBase)
-                     .addChild(publisher.getIdentifier(), publisher.getYear())
+                     .addChild(publisher.getIdentifier(), year)
                      .getUri();
         return new FetchByIdAndYearResponse(id,
                                             publisher.getName(),

--- a/src/main/java/no/sikt/nva/pubchannels/handler/fetch/publisher/FetchPublisherByIdentifierAndYearHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/fetch/publisher/FetchPublisherByIdentifierAndYearHandler.java
@@ -37,10 +37,11 @@ public class FetchPublisherByIdentifierAndYearHandler extends
 
         var publisherIdBaseUri = constructPublicationChannelIdBaseUri(PUBLISHER_PATH_ELEMENT);
 
+        var requestYear = request.getYear();
         return FetchByIdAndYearResponse.create(publisherIdBaseUri,
                                                (ThirdPartyPublisher) publicationChannelClient.getChannel(
                                                    ChannelType.PUBLISHER,
                                                    request.getIdentifier(),
-                                                   request.getYear()));
+                                                   requestYear), requestYear);
     }
 }

--- a/src/main/java/no/sikt/nva/pubchannels/handler/fetch/series/FetchByIdAndYearResponse.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/fetch/series/FetchByIdAndYearResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.net.URI;
 import java.util.Objects;
+import java.util.Optional;
 import no.sikt.nva.pubchannels.handler.ScientificValue;
 import no.sikt.nva.pubchannels.handler.ThirdPartySeries;
 import no.sikt.nva.pubchannels.model.Contexts;
@@ -53,16 +54,17 @@ public class FetchByIdAndYearResponse {
         this.sameAs = sameAs;
     }
 
-    public static FetchByIdAndYearResponse create(URI selfUriBase, ThirdPartySeries channel) {
+    public static FetchByIdAndYearResponse create(URI selfUriBase, ThirdPartySeries series, String requestedYear) {
+        var year = Optional.ofNullable(series.getYear()).orElse(requestedYear);
         var id = UriWrapper.fromUri(selfUriBase)
-                     .addChild(channel.getIdentifier(), channel.getYear())
+                     .addChild(series.getIdentifier(), year)
                      .getUri();
         return new FetchByIdAndYearResponse(id,
-                                            channel.getName(),
-                                            channel.getOnlineIssn(),
-                                            channel.getPrintIssn(),
-                                            channel.getScientificValue(),
-                                            channel.getHomepage());
+                                            series.getName(),
+                                            series.getOnlineIssn(),
+                                            series.getPrintIssn(),
+                                            series.getScientificValue(),
+                                            series.getHomepage());
     }
 
     public String getType() {

--- a/src/main/java/no/sikt/nva/pubchannels/handler/fetch/series/FetchSeriesByIdentifierAndYearHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/fetch/series/FetchSeriesByIdentifierAndYearHandler.java
@@ -36,9 +36,10 @@ public class FetchSeriesByIdentifierAndYearHandler extends
 
         var publisherIdBaseUri = constructPublicationChannelIdBaseUri(SERIES_PATH_ELEMENT);
 
+        var requestYear = request.getYear();
         return FetchByIdAndYearResponse.create(publisherIdBaseUri,
                                                (ThirdPartySeries) publicationChannelClient.getChannel(
                                                    ChannelType.SERIES,
-                                                   request.getIdentifier(), request.getYear()));
+                                                   request.getIdentifier(), requestYear), requestYear);
     }
 }

--- a/src/test/java/no/sikt/nva/pubchannels/handler/DataportenBodyBuilder.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/DataportenBodyBuilder.java
@@ -1,8 +1,8 @@
 package no.sikt.nva.pubchannels.handler;
 
+import static java.util.Objects.nonNull;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import no.sikt.nva.pubchannels.dataporten.model.DataportenLevel;
 import no.sikt.nva.pubchannels.dataporten.model.search.DataPortenEntityPageInformation;
@@ -52,7 +52,7 @@ public class DataportenBodyBuilder {
     }
 
     public DataportenBodyBuilder withLevel(DataportenLevel level) {
-        if (Objects.nonNull(level)) {
+        if (nonNull(level)) {
             bodyMap.put("levelElementDto", level);
         }
         return this;

--- a/src/test/java/no/sikt/nva/pubchannels/handler/TestUtils.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/TestUtils.java
@@ -45,7 +45,7 @@ import nva.commons.core.paths.UriWrapper;
 public class TestUtils {
 
     public static final String PAGERESULT_FIELD = "pageresult";
-    private static final int YEAR_START = 1900;
+    public static final int YEAR_START = 1900;
     private static final ScientificValueMapper mapper = new ScientificValueMapper();
 
     private TestUtils() {
@@ -271,7 +271,7 @@ public class TestUtils {
                         .withStatus(httpStatus)));
     }
 
-    public static String createDataportenJournalResponse(int year, String originalTitle, String pid, String eissn,
+    public static String createDataportenJournalResponse(Integer year, String originalTitle, String pid, String eissn,
                                                          String pissn, URI kurl, String level) {
         return new DataportenBodyBuilder()
                    .withPid(pid)
@@ -283,7 +283,7 @@ public class TestUtils {
                    .build();
     }
 
-    public static String createDataportenPublisherResponse(int year, String name, String pid, String isbnPrefix,
+    public static String createDataportenPublisherResponse(Integer year, String name, String pid, String isbnPrefix,
                                                            URI kurl, String level) {
         return new DataportenBodyBuilder()
                    .withPid(pid)

--- a/src/test/java/no/sikt/nva/pubchannels/handler/fetch/journal/FetchByIdAndYearResponseTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/fetch/journal/FetchByIdAndYearResponseTest.java
@@ -64,6 +64,6 @@ class FetchByIdAndYearResponseTest {
                 return randomString();
             }
         };
-        return FetchByIdAndYearResponse.create(randomUri(), journal);
+        return FetchByIdAndYearResponse.create(randomUri(), journal, randomString());
     }
 }

--- a/src/test/java/no/sikt/nva/pubchannels/handler/fetch/journal/FetchJournalByIdentifierAndYearHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/fetch/journal/FetchJournalByIdentifierAndYearHandlerTest.java
@@ -83,6 +83,24 @@ class FetchJournalByIdentifierAndYearHandlerTest {
         assertThat(actualJournal, is(equalTo(expectedJournal)));
     }
 
+    @Test
+    void shouldReturnChannelIdWithRequestedYearIfThirdPartyDoesNotProvideYear() throws IOException {
+        var year = TestUtils.randomYear();
+        var identifier = mockRegistry.randomJournalWithThirdPartyYearValueNull(year);
+        var input = constructRequest(String.valueOf(year), identifier);
+
+        handlerUnderTest.handleRequest(input, output, context);
+
+        var response = GatewayResponse.fromOutputStream(output, FetchByIdAndYearResponse.class);
+
+        var statusCode = response.getStatusCode();
+        assertThat(statusCode, is(equalTo(HttpURLConnection.HTTP_OK)));
+
+        var actualJournal = response.getBodyObject(FetchByIdAndYearResponse.class);
+        var expectedJournal = mockRegistry.getJournal(identifier);
+        assertThat(actualJournal, is(equalTo(expectedJournal)));
+    }
+
     @ParameterizedTest(name = "year {0} is invalid")
     @MethodSource("invalidYearsProvider")
     void shouldReturnBadRequestWhenPathParameterYearIsNotValid(String year)

--- a/src/test/java/no/sikt/nva/pubchannels/handler/fetch/publisher/FetchByIdAndYearResponseTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/fetch/publisher/FetchByIdAndYearResponseTest.java
@@ -59,6 +59,6 @@ class FetchByIdAndYearResponseTest {
                 return randomUri();
             }
         };
-        return FetchByIdAndYearResponse.create(randomUri(), publisher);
+        return FetchByIdAndYearResponse.create(randomUri(), publisher, randomString());
     }
 }

--- a/src/test/java/no/sikt/nva/pubchannels/handler/fetch/series/FetchByIdAndYearResponseTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/fetch/series/FetchByIdAndYearResponseTest.java
@@ -64,6 +64,6 @@ class FetchByIdAndYearResponseTest {
                 return randomString();
             }
         };
-        return FetchByIdAndYearResponse.create(randomUri(), series);
+        return FetchByIdAndYearResponse.create(randomUri(), series, randomString());
     }
 }


### PR DESCRIPTION
On _fetch by year and id_ handlers: should return response id with requested year if third party does not provide year