### PR TITLE
Added isbnPrefix validation in CreatePublisherHandler

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -778,7 +778,7 @@ components:
         id: 'https://example.org/publisher/151f411d-68cd-4c7a-9cbb-daf00e0326ce/2010'
         type: 'Publisher'
         name: 'The publisher of eternal fury'
-        isbnPrefix: '123-82-432'
+        isbnPrefix: '12345-1234567'
         scientificValue: 'LEVEL_1'
         sameAs: 'https://kanalregister.hkdir.no/publiseringskanaler/KanalTidsskriftInfo?pid=151f411d-68cd-4c7a-9cbb-daf00e0326ce'
       summary: A sample publisher

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -588,6 +588,7 @@ components:
           type: string
           nullable: true
           description: The isbnPrefix of the publsher
+          pattern: ^(?:97(8|9)-)?[0-9]{1,5}-[0-9]{1,7}$
         scientificValue:
           $ref: '#/components/schemas/ScientificValue'
         sameAs:
@@ -603,6 +604,7 @@ components:
           type: string
           nullable: true
           description: The isbnPrefix of the publsher
+          pattern: ^(?:97(8|9)-)?[0-9]{1,5}-[0-9]{1,7}$
         homepage:
           type: string
           format: uri
@@ -768,7 +770,7 @@ components:
     CreatePublisherExample:
       value:
         name: 'The publisher of eternal fury'
-        isbnPrefix: '123-82-432'
+        isbnPrefix: '12345-1234567'
         homepage: 'https://publisher-of-eternal.fury.no'
       summary: A sample create publisher
     PublisherResponseExample:

--- a/src/main/java/no/sikt/nva/pubchannels/handler/create/publisher/CreatePublisherHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/create/publisher/CreatePublisherHandler.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.pubchannels.handler.create.publisher;
 
+import static no.sikt.nva.pubchannels.handler.validator.Validator.validateOptionalIsbnPrefix;
 import static no.sikt.nva.pubchannels.handler.validator.Validator.validateOptionalUrl;
 import static no.sikt.nva.pubchannels.handler.validator.Validator.validateString;
 import static nva.commons.core.attempt.Try.attempt;
@@ -50,6 +51,7 @@ public class CreatePublisherHandler extends CreateHandler<CreatePublisherRequest
 
     private CreatePublisherRequest validate(CreatePublisherRequest input) {
         validateString(input.getName(), 5, 300, "Name");
+        validateOptionalIsbnPrefix(input.getIsbnPrefix(), "Isbn prefix");
         validateOptionalUrl(input.getHomepage(), "Homepage");
         return input;
     }

--- a/src/main/java/no/sikt/nva/pubchannels/handler/validator/Validator.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/validator/Validator.java
@@ -1,18 +1,20 @@
 package no.sikt.nva.pubchannels.handler.validator;
 
+import static java.lang.String.format;
+import static java.util.Objects.nonNull;
+import static nva.commons.core.attempt.Try.attempt;
+import java.time.Year;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.regex.Pattern;
 import nva.commons.core.JacocoGenerated;
 import org.apache.commons.validator.routines.ISSNValidator;
 import org.apache.commons.validator.routines.UrlValidator;
 
-import java.time.Year;
-import java.util.Objects;
-import java.util.UUID;
-
-import static java.lang.String.format;
-import static nva.commons.core.attempt.Try.attempt;
-
 public final class Validator {
 
+    public static final String ISBN_PREFIX_PATTERN = "^(?:97(8|9)-)?[0-9]{1,5}-[0-9]{1,7}$";
+    public static final int MAX_LENGTH_ISBN_PREFIX = 13;
     private static final String IS_REQUIRED_STRING = "%s is required.";
 
     @JacocoGenerated
@@ -26,6 +28,15 @@ public final class Validator {
         }
         if (value.length() > maxLength) {
             throw new ValidationException(format("%s is too long. Maximum length is %d", name, maxLength));
+        }
+    }
+
+    public static void validateOptionalIsbnPrefix(String isbnPrefix, String name) {
+        if (nonNull(isbnPrefix) && isbnPrefix.length() > MAX_LENGTH_ISBN_PREFIX) {
+            throw new ValidationException(format("%s is too long. Maximum length is %d", name, MAX_LENGTH_ISBN_PREFIX));
+        }
+        if (nonNull(isbnPrefix) && !Pattern.matches(ISBN_PREFIX_PATTERN, isbnPrefix)) {
+            throw new ValidationException(format("%s has an invalid format.", name));
         }
     }
 
@@ -44,20 +55,19 @@ public final class Validator {
     public static void validateUuid(String value, String name) {
         Objects.requireNonNull(value, format(IS_REQUIRED_STRING, name));
         attempt(() -> UUID.fromString(value))
-                .orElseThrow(failure ->
-                        new ValidationException(format("%s has an invalid UUIDv4 format", name)));
+            .orElseThrow(failure ->
+                             new ValidationException(format("%s has an invalid UUIDv4 format", name)));
     }
 
     public static void validateYear(String value, Year minAcceptableYear, String name) {
         Objects.requireNonNull(value, format(IS_REQUIRED_STRING, name));
         var year = attempt(() -> Year.parse(value))
-                .orElseThrow(failure -> new ValidationException(format("%s field is not a valid year.", name)));
+                       .orElseThrow(failure -> new ValidationException(format("%s field is not a valid year.", name)));
         var now = Year.now();
         if (year.isBefore(minAcceptableYear) || year.isAfter(now.plusYears(1))) {
             throw new ValidationException(
-                    format("%s is not between the year %d and %d", name, minAcceptableYear.getValue(), now.getValue()));
+                format("%s is not between the year %d and %d", name, minAcceptableYear.getValue(), now.getValue()));
         }
-
     }
 
     public static void validatePagination(int offset, int size) {

--- a/src/test/java/no/sikt/nva/pubchannels/handler/TestUtils.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/TestUtils.java
@@ -31,7 +31,6 @@ import java.time.Year;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Random;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -47,6 +46,7 @@ public class TestUtils {
 
     public static final String PAGERESULT_FIELD = "pageresult";
     public static final int YEAR_START = 1900;
+    public static final String VALID_ISBN_PREFIX = "12345-1234567";
     private static final ScientificValueMapper mapper = new ScientificValueMapper();
 
     private TestUtils() {
@@ -97,11 +97,8 @@ public class TestUtils {
                    .collect(SingletonCollector.collectOrElse(null));
     }
 
-    //TODO: Check isbn prefix format with PO
-    public static int randomIsbnPrefix() {
-        int min = 1000;
-        int max = 9999;
-        return new Random().nextInt(max - min + 1) + min;
+    public static String validIsbnPrefix() {
+        return VALID_ISBN_PREFIX;
     }
 
     public static String randomLevel() {
@@ -119,7 +116,7 @@ public class TestUtils {
     public static List<String> getDataportenSearchPublisherResult(int year, String name, int maxNr) {
         return IntStream.range(0, maxNr)
                    .mapToObj(i -> createDataportenPublisherResponse(year, name, UUID.randomUUID().toString(),
-                                                                    String.valueOf(randomIsbnPrefix()),
+                                                                    String.valueOf(validIsbnPrefix()),
                                                                     randomUri(), randomLevel()))
                    .collect(Collectors.toList());
     }

--- a/src/test/java/no/sikt/nva/pubchannels/handler/fetch/publisher/FetchPublisherByIdentifierAndYearHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/fetch/publisher/FetchPublisherByIdentifierAndYearHandlerTest.java
@@ -6,7 +6,7 @@ import static no.sikt.nva.pubchannels.handler.TestUtils.createDataportenPublishe
 import static no.sikt.nva.pubchannels.handler.TestUtils.createPublisher;
 import static no.sikt.nva.pubchannels.handler.TestUtils.mockDataportenResponse;
 import static no.sikt.nva.pubchannels.handler.TestUtils.mockResponseWithHttpStatus;
-import static no.sikt.nva.pubchannels.handler.TestUtils.randomIsbnPrefix;
+import static no.sikt.nva.pubchannels.handler.TestUtils.validIsbnPrefix;
 import static no.sikt.nva.pubchannels.handler.TestUtils.randomYear;
 import static no.sikt.nva.pubchannels.handler.TestUtils.scientificValueToLevel;
 import static no.sikt.nva.pubchannels.handler.TestUtils.setupInterruptedClient;
@@ -37,7 +37,6 @@ import nva.commons.core.Environment;
 import nva.commons.logutils.LogUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -225,7 +224,7 @@ class FetchPublisherByIdentifierAndYearHandlerTest {
 
     private FetchByIdAndYearResponse mockPublisherFound(int year, String identifier) {
         var name = randomString();
-        var isbnPrefix = String.valueOf(randomIsbnPrefix());
+        var isbnPrefix = String.valueOf(validIsbnPrefix());
         var scientificValue = randomElement(ScientificValue.values());
         var level = scientificValueToLevel(scientificValue);
         var landingPage = randomUri();
@@ -239,7 +238,7 @@ class FetchPublisherByIdentifierAndYearHandlerTest {
 
     private FetchByIdAndYearResponse mockPublisherFoundYearValueNull(String year, String identifier) {
         var name = randomString();
-        var isbnPrefix = String.valueOf(randomIsbnPrefix());
+        var isbnPrefix = String.valueOf(validIsbnPrefix());
         var scientificValue = randomElement(ScientificValue.values());
         var level = scientificValueToLevel(scientificValue);
         var landingPage = randomUri();


### PR DESCRIPTION
Added isbnPrefix validation in CreatePublisherHandler.

See Kanalregister documentation: 
- https://dbh.hkdir.no/static/files/dokumenter/api/API_KANALREGISTER_NVA.pdf
- https://kar-test.dataporten-api.no/swagger-ui.html#!/create45publisher/createpidPublisherUsingPOST