### PR TITLE
Np 46326 Handle redirects

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -75,6 +75,13 @@ paths:
               examples:
                 objectExample:
                   $ref: '#/components/examples/JournalResponseExample'
+        301:
+          description: Moved permanently
+          headers:
+            Location:
+              schema:
+                type: string
+              description: A URI to the new resource
         400:
           $ref: '#/components/responses/400'
         404:
@@ -229,6 +236,13 @@ paths:
               examples:
                 objectExample:
                   $ref: '#/components/examples/PublisherResponseExample'
+        301:
+          description: Moved permanently
+          headers:
+            Location:
+              schema:
+                type: string
+              description: A URI to the new resource
         400:
           $ref: '#/components/responses/400'
         404:
@@ -383,6 +397,13 @@ paths:
               examples:
                 objectExample:
                   $ref: '#/components/examples/SeriesExample'
+        301:
+          description: Moved permanently
+          headers:
+            Location:
+              schema:
+                type: string
+              description: A URI to the new resource
         400:
           $ref: '#/components/responses/400'
         404:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 junit = { strictly = '5.8.2' }
-nva-commons = {strictly = '1.28.0'}
+nva-commons = {strictly = '1.28.5'}
 jackson = { strictly = '2.13.3' }
 mockito = { strictly = '4.5.1' }
 hamcrest = { strictly = '2.2' }

--- a/src/main/java/no/sikt/nva/pubchannels/dataporten/PublicationChannelMovedException.java
+++ b/src/main/java/no/sikt/nva/pubchannels/dataporten/PublicationChannelMovedException.java
@@ -1,0 +1,25 @@
+package no.sikt.nva.pubchannels.dataporten;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+import nva.commons.apigateway.exceptions.RedirectException;
+
+public class PublicationChannelMovedException extends RedirectException {
+
+    private final URI location;
+
+    public PublicationChannelMovedException(String message, URI location) {
+        super(message);
+        this.location = location;
+    }
+
+    @Override
+    public URI getLocation() {
+        return location;
+    }
+
+    @Override
+    protected Integer statusCode() {
+        return HttpURLConnection.HTTP_MOVED_PERM;
+    }
+}

--- a/src/main/java/no/sikt/nva/pubchannels/handler/fetch/FetchByIdentifierAndYearHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/fetch/FetchByIdentifierAndYearHandler.java
@@ -53,6 +53,14 @@ public abstract class FetchByIdentifierAndYearHandler<I, O> extends ApiGatewayHa
                    .getUri();
     }
 
+    protected URI constructNewLocation(String pathElement, URI channelRegistryLocation, String year) {
+        var newIdentifier = UriWrapper.fromUri(channelRegistryLocation).getPath().getPathElementByIndexFromEnd(1);
+        return UriWrapper.fromUri(constructPublicationChannelIdBaseUri(pathElement))
+                   .addChild(newIdentifier)
+                   .addChild(year)
+                   .getUri();
+    }
+
     @Override
     protected List<MediaType> listSupportedMediaTypes() {
         return List.of(

--- a/src/test/java/no/sikt/nva/pubchannels/handler/TestUtils.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/TestUtils.java
@@ -1,6 +1,7 @@
 package no.sikt.nva.pubchannels.handler;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static no.sikt.nva.pubchannels.HttpHeaders.ACCEPT;
@@ -75,6 +76,17 @@ public class TestUtils {
                         .withStatus(HttpURLConnection.HTTP_OK)
                         .withHeader("Content-Type", "application/json;charset=UTF-8")
                         .withBody(responseBody)));
+    }
+
+    public static void mockRedirectedClient(String requestedIdentifier, String location, String year,
+                                            String path) {
+        stubFor(
+            get(path + requestedIdentifier + "/" + year)
+                .withHeader(ACCEPT, equalTo("application/json"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(HttpURLConnection.HTTP_MOVED_PERM)
+                        .withHeader("Location", location)));
     }
 
     public static int randomYear() {
@@ -321,6 +333,12 @@ public class TestUtils {
                 .collect(Collectors.toList());
         var entityResult = createEntityResultObjectNode(resultsWithOffsetAndSize);
         return buildDataportenSearchResponse(results, entityResult);
+    }
+
+    public static String constructExpectedLocation(String newIdentifier, String year, String channelPath) {
+        return UriWrapper.fromHost(LOCALHOST)
+                   .addChild(CUSTOM_DOMAIN_BASE_PATH, channelPath, newIdentifier, year)
+                   .toString();
     }
 
     private static String currentYear() {

--- a/src/test/java/no/sikt/nva/pubchannels/handler/fetch/journal/PublicationChannelMockClient.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/fetch/journal/PublicationChannelMockClient.java
@@ -23,6 +23,9 @@ import nva.commons.core.SingletonCollector;
 
 public class PublicationChannelMockClient {
 
+    public static final String ACCEPT = "Accept";
+    public static final String APPLICATION_JSON = "application/json";
+    public static final String CHANNEL_REGISTRY_JOURNAL_PATH = "/findjournal/";
     private final Map<String, FetchByIdAndYearResponse> journalsByIdentifier = new ConcurrentHashMap<>();
 
     public void notFoundJournal(String identifier, String year) {
@@ -71,15 +74,29 @@ public class PublicationChannelMockClient {
         return identifier;
     }
 
+    public void redirect(String requestedIdentifier, String location, String year) {
+        stubFor(
+            get(CHANNEL_REGISTRY_JOURNAL_PATH + requestedIdentifier + "/" + year)
+                .withHeader(ACCEPT, equalTo(APPLICATION_JSON))
+                .willReturn(
+                    aResponse()
+                        .withStatus(HttpURLConnection.HTTP_MOVED_PERM)
+                        .withHeader("Location", location)));
+    }
+
     private static void mockDataporten(int year, String identifier, String responseBody) {
         stubFor(
-            get("/findjournal/" + identifier + "/" + year)
-                .withHeader("Accept", equalTo("application/json"))
+            get(CHANNEL_REGISTRY_JOURNAL_PATH + identifier + "/" + year)
+                .withHeader(ACCEPT, equalTo(APPLICATION_JSON))
                 .willReturn(
                     aResponse()
                         .withStatus(HttpURLConnection.HTTP_OK)
                         .withHeader("Content-Type", "application/json;charset=UTF-8")
                         .withBody(responseBody)));
+    }
+
+    private URI constructUri(String newIdentifier) {
+        return null;
     }
 
     private void createJournalAndAddToMap(Integer year, String identifier, String name, String electronicIssn,

--- a/src/test/java/no/sikt/nva/pubchannels/handler/fetch/journal/PublicationChannelMockClient.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/fetch/journal/PublicationChannelMockClient.java
@@ -95,10 +95,6 @@ public class PublicationChannelMockClient {
                         .withBody(responseBody)));
     }
 
-    private URI constructUri(String newIdentifier) {
-        return null;
-    }
-
     private void createJournalAndAddToMap(Integer year, String identifier, String name, String electronicIssn,
                                           String issn,
                                           ScientificValue scientificValue, URI landingPage) {

--- a/src/test/java/no/sikt/nva/pubchannels/handler/fetch/publisher/FetchPublisherByIdentifierAndYearHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/fetch/publisher/FetchPublisherByIdentifierAndYearHandlerTest.java
@@ -6,6 +6,7 @@ import static no.sikt.nva.pubchannels.handler.TestUtils.constructRequest;
 import static no.sikt.nva.pubchannels.handler.TestUtils.createDataportenPublisherResponse;
 import static no.sikt.nva.pubchannels.handler.TestUtils.createPublisher;
 import static no.sikt.nva.pubchannels.handler.TestUtils.mockDataportenResponse;
+import static no.sikt.nva.pubchannels.handler.TestUtils.mockRedirectedClient;
 import static no.sikt.nva.pubchannels.handler.TestUtils.mockResponseWithHttpStatus;
 import static no.sikt.nva.pubchannels.handler.TestUtils.randomYear;
 import static no.sikt.nva.pubchannels.handler.TestUtils.scientificValueToLevel;
@@ -18,6 +19,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
@@ -27,15 +29,18 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.net.http.HttpResponse;
 import java.time.LocalDate;
 import java.util.UUID;
 import java.util.stream.Stream;
 import no.sikt.nva.pubchannels.dataporten.DataportenPublicationChannelClient;
 import no.sikt.nva.pubchannels.handler.ScientificValue;
+import no.sikt.nva.pubchannels.handler.TestUtils;
 import no.unit.nva.stubs.FakeContext;
 import no.unit.nva.stubs.WiremockHttpClient;
 import nva.commons.apigateway.GatewayResponse;
 import nva.commons.core.Environment;
+import nva.commons.core.paths.UriWrapper;
 import nva.commons.logutils.LogUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,12 +55,14 @@ import org.zalando.problem.Problem;
 @WireMockTest(httpsEnabled = true)
 class FetchPublisherByIdentifierAndYearHandlerTest {
 
-    public static final String SELF_URI_BASE = "https://localhost/publication-channels/publisher";
+    private static final String PUBLISHER_PATH = "publisher";
+    private static final String SELF_URI_BASE = "https://localhost/publication-channels/" + PUBLISHER_PATH;
     private static final String DATAPORTEN_PATH_ELEMENT = "/findpublisher/";
     private static final Context context = new FakeContext();
     private FetchPublisherByIdentifierAndYearHandler handlerUnderTest;
     private ByteArrayOutputStream output;
     private Environment environment;
+    private String dataportenBaseUri;
 
     @BeforeEach
     void setup(WireMockRuntimeInfo runtimeInfo) {
@@ -63,10 +70,10 @@ class FetchPublisherByIdentifierAndYearHandlerTest {
         when(environment.readEnv("ALLOWED_ORIGIN")).thenReturn("*");
         when(environment.readEnv("API_DOMAIN")).thenReturn("localhost");
         when(environment.readEnv("CUSTOM_DOMAIN_BASE_PATH")).thenReturn("publication-channels");
-
-        var dataportenBaseUri = URI.create(runtimeInfo.getHttpsBaseUrl());
+        dataportenBaseUri = runtimeInfo.getHttpsBaseUrl();
         var httpClient = WiremockHttpClient.create();
-        var publicationChannelClient = new DataportenPublicationChannelClient(httpClient, dataportenBaseUri, null);
+        var publicationChannelClient = new DataportenPublicationChannelClient(httpClient, URI.create(dataportenBaseUri),
+                                                                              null);
         this.handlerUnderTest = new FetchPublisherByIdentifierAndYearHandler(environment, publicationChannelClient);
         this.output = new ByteArrayOutputStream();
     }
@@ -119,7 +126,6 @@ class FetchPublisherByIdentifierAndYearHandlerTest {
         assertThat(statusCode, is(equalTo(HttpURLConnection.HTTP_OK)));
         var contentType = response.getHeaders().get(CONTENT_TYPE);
         assertThat(contentType, is(equalTo(expectedMediaType)));
-
     }
 
     @Test
@@ -244,6 +250,23 @@ class FetchPublisherByIdentifierAndYearHandlerTest {
 
         var problem = response.getBodyObject(Problem.class);
         assertThat(problem.getDetail(), is(equalTo("Unable to reach upstream!")));
+    }
+
+    @Test
+    void shouldReturnRedirectWhenChannelRegistryReturnsRedirect() throws IOException {
+        var year = String.valueOf(randomYear());
+        var requestedIdentifier = UUID.randomUUID().toString();
+        var newIdentifier = UUID.randomUUID().toString();
+        var newChannelRegistryLocation = UriWrapper.fromHost(dataportenBaseUri)
+                                             .addChild(DATAPORTEN_PATH_ELEMENT, newIdentifier, year)
+                                             .toString();
+        mockRedirectedClient(requestedIdentifier, newChannelRegistryLocation, year, DATAPORTEN_PATH_ELEMENT);
+        handlerUnderTest.handleRequest(constructRequest(year, requestedIdentifier, MediaType.ANY_TYPE), output,
+                                       context);
+        var response = GatewayResponse.fromOutputStream(output, HttpResponse.class);
+        assertEquals(HttpURLConnection.HTTP_MOVED_PERM, response.getStatusCode());
+        var expectedLocation = TestUtils.constructExpectedLocation(newIdentifier, year, PUBLISHER_PATH);
+        assertEquals(expectedLocation, response.getHeaders().get("Location"));
     }
 
     private static Stream<String> invalidYearsProvider() {


### PR DESCRIPTION
Handle redirects from publication channel registry in following handlers: `FetchJournalByIdentifierAndYearHandler`, `FetchSeriesByIdentifierAndYearHandler`, `FetchPublisherByIdentifierAndYearHandler`

Construct a new `Location` header for proxy when passing redirect through.