### PR TITLE
NP-46876-security-headers

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 junit = { strictly = '5.10.0' }
-nva-commons = {strictly = '1.39.2'}
+nva-commons = {strictly = '1.39.3'}
 jackson = { strictly = '2.16.1' }
 mockito = { strictly = '4.5.1' }
 hamcrest = { strictly = '2.2' }


### PR DESCRIPTION
ApiGatewayHandler i  nva-commons = {strictly = '1.39.3'} kommer nå med to securty headers.