### PR TITLE
NVA commons version 1.40.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 junit = { strictly = '5.10.0' }
-nva-commons = {strictly = '1.39.3'}
+nva-commons = {strictly = '1.40.3'}
 jackson = { strictly = '2.16.1' }
 mockito = { strictly = '4.5.1' }
 hamcrest = { strictly = '2.2' }

--- a/src/main/java/no/sikt/nva/pubchannels/handler/create/journal/CreateJournalHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/create/journal/CreateJournalHandler.java
@@ -4,7 +4,6 @@ import static no.sikt.nva.pubchannels.dataporten.ChannelType.JOURNAL;
 import static no.sikt.nva.pubchannels.handler.validator.Validator.validateOptionalIssn;
 import static no.sikt.nva.pubchannels.handler.validator.Validator.validateOptionalUrl;
 import static no.sikt.nva.pubchannels.handler.validator.Validator.validateString;
-import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import java.util.Map;
 import no.sikt.nva.pubchannels.HttpHeaders;
@@ -12,6 +11,7 @@ import no.sikt.nva.pubchannels.dataporten.model.create.DataportenCreateJournalRe
 import no.sikt.nva.pubchannels.handler.PublicationChannelClient;
 import no.sikt.nva.pubchannels.handler.ThirdPartyJournal;
 import no.sikt.nva.pubchannels.handler.create.CreateHandler;
+import no.sikt.nva.pubchannels.handler.validator.ValidationException;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.BadRequestException;
@@ -32,30 +32,36 @@ public class CreateJournalHandler extends CreateHandler<CreateJournalRequest, Cr
     }
 
     @Override
+    protected void validateRequest(CreateJournalRequest createJournalRequest, RequestInfo requestInfo, Context context)
+        throws ApiGatewayException {
+        userIsAuthorizedToCreate(requestInfo);
+        validate(createJournalRequest);
+    }
+
+    @Override
     protected CreateJournalResponse processInput(CreateJournalRequest input, RequestInfo requestInfo,
                                                  Context context) throws ApiGatewayException {
-        userIsAuthorizedToCreate(requestInfo);
-        var validInput = attempt(() -> validate(input))
-                             .map(CreateJournalHandler::getClientRequest)
-                             .orElseThrow(failure -> new BadRequestException(failure.getException().getMessage()));
-        var createResponse = publicationChannelClient.createJournal(validInput);
-        var createdUri = constructIdUri(JOURNAL_PATH_ELEMENT, createResponse.getPid());
+        var response = publicationChannelClient.createJournal(getClientRequest(input));
+        var createdUri = constructIdUri(JOURNAL_PATH_ELEMENT, response.getPid());
         addAdditionalHeaders(() -> Map.of(HttpHeaders.LOCATION, createdUri.toString()));
         return CreateJournalResponse.create(
             createdUri,
-            (ThirdPartyJournal) publicationChannelClient.getChannel(JOURNAL, createResponse.getPid(), getYear()));
+            (ThirdPartyJournal) publicationChannelClient.getChannel(JOURNAL, response.getPid(), getYear()));
     }
 
     private static DataportenCreateJournalRequest getClientRequest(CreateJournalRequest request) {
-        return new DataportenCreateJournalRequest(request.getName(), request.getPrintIssn(), request.getOnlineIssn(),
-                                                  request.getHomepage());
+        return new DataportenCreateJournalRequest(request.name(), request.printIssn(), request.onlineIssn(),
+                                                  request.homepage());
     }
 
-    private CreateJournalRequest validate(CreateJournalRequest input) {
-        validateString(input.getName(), 5, 300, "Name");
-        validateOptionalIssn(input.getPrintIssn(), "PrintIssn");
-        validateOptionalIssn(input.getOnlineIssn(), "OnlineIssn");
-        validateOptionalUrl(input.getHomepage(), "Homepage");
-        return input;
+    private void validate(CreateJournalRequest input) throws BadRequestException {
+        try {
+            validateString(input.name(), 5, 300, "Name");
+            validateOptionalIssn(input.printIssn(), "PrintIssn");
+            validateOptionalIssn(input.onlineIssn(), "OnlineIssn");
+            validateOptionalUrl(input.homepage(), "Homepage");
+        } catch (ValidationException exception) {
+            throw new BadRequestException(exception.getMessage());
+        }
     }
 }

--- a/src/main/java/no/sikt/nva/pubchannels/handler/create/journal/CreateJournalRequest.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/create/journal/CreateJournalRequest.java
@@ -1,39 +1,8 @@
 package no.sikt.nva.pubchannels.handler.create.journal;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+public record CreateJournalRequest(String name,
+                                   String printIssn,
+                                   String onlineIssn,
+                                   String homepage) {
 
-public record CreateJournalRequest(@JsonProperty(NAME_FIELD) String name,
-                                   @JsonProperty(PRINT_ISSN_FIELD) String printIssn,
-                                   @JsonProperty(ONLINE_ISSN_FIELD) String onlineIssn,
-                                   @JsonProperty(HOMEPAGE_FIELD) String homepage) {
-
-    private static final String NAME_FIELD = "name";
-    private static final String PRINT_ISSN_FIELD = "printIssn";
-    private static final String ONLINE_ISSN_FIELD = "onlineIssn";
-    private static final String HOMEPAGE_FIELD = "homepage";
-
-    @JsonCreator
-    public CreateJournalRequest {
-    }
-
-    @Override
-    public String name() {
-        return name;
-    }
-
-    @Override
-    public String printIssn() {
-        return printIssn;
-    }
-
-    @Override
-    public String onlineIssn() {
-        return onlineIssn;
-    }
-
-    @Override
-    public String homepage() {
-        return homepage;
-    }
 }

--- a/src/main/java/no/sikt/nva/pubchannels/handler/create/journal/CreateJournalRequest.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/create/journal/CreateJournalRequest.java
@@ -3,47 +3,37 @@ package no.sikt.nva.pubchannels.handler.create.journal;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-class CreateJournalRequest {
+public record CreateJournalRequest(@JsonProperty(NAME_FIELD) String name,
+                                   @JsonProperty(PRINT_ISSN_FIELD) String printIssn,
+                                   @JsonProperty(ONLINE_ISSN_FIELD) String onlineIssn,
+                                   @JsonProperty(HOMEPAGE_FIELD) String homepage) {
+
     private static final String NAME_FIELD = "name";
     private static final String PRINT_ISSN_FIELD = "printIssn";
     private static final String ONLINE_ISSN_FIELD = "onlineIssn";
     private static final String HOMEPAGE_FIELD = "homepage";
 
-    @JsonProperty(NAME_FIELD)
-    private final String name;
-    @JsonProperty(PRINT_ISSN_FIELD)
-    private final String printIssn;
-    @JsonProperty(ONLINE_ISSN_FIELD)
-    private final String onlineIssn;
-    @JsonProperty(HOMEPAGE_FIELD)
-    private final String homepage;
-
     @JsonCreator
-    public CreateJournalRequest(
-            @JsonProperty(NAME_FIELD) String name,
-            @JsonProperty(PRINT_ISSN_FIELD) String printIssn,
-            @JsonProperty(ONLINE_ISSN_FIELD) String onlineIssn,
-            @JsonProperty(HOMEPAGE_FIELD)String homepage
-    ) {
-        this.name = name;
-        this.printIssn = printIssn;
-        this.onlineIssn = onlineIssn;
-        this.homepage = homepage;
+    public CreateJournalRequest {
     }
 
-    public String getName() {
+    @Override
+    public String name() {
         return name;
     }
 
-    public String getPrintIssn() {
+    @Override
+    public String printIssn() {
         return printIssn;
     }
 
-    public String getOnlineIssn() {
+    @Override
+    public String onlineIssn() {
         return onlineIssn;
     }
 
-    public String getHomepage() {
+    @Override
+    public String homepage() {
         return homepage;
     }
 }

--- a/src/main/java/no/sikt/nva/pubchannels/handler/create/publisher/CreatePublisherRequest.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/create/publisher/CreatePublisherRequest.java
@@ -1,32 +1,7 @@
 package no.sikt.nva.pubchannels.handler.create.publisher;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+public record CreatePublisherRequest(String name,
+                                     String isbnPrefix,
+                                     String homepage) {
 
-public record CreatePublisherRequest(@JsonProperty(NAME_FIELD) String name,
-                                     @JsonProperty(ISBN_PREFIX_FIELD) String isbnPrefix,
-                                     @JsonProperty(HOMEPAGE_FIELD) String homepage) {
-
-    private static final String NAME_FIELD = "name";
-    private static final String ISBN_PREFIX_FIELD = "isbnPrefix";
-    private static final String HOMEPAGE_FIELD = "homepage";
-
-    @JsonCreator
-    public CreatePublisherRequest {
-    }
-
-    @Override
-    public String name() {
-        return name;
-    }
-
-    @Override
-    public String isbnPrefix() {
-        return isbnPrefix;
-    }
-
-    @Override
-    public String homepage() {
-        return homepage;
-    }
 }

--- a/src/main/java/no/sikt/nva/pubchannels/handler/create/publisher/CreatePublisherRequest.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/create/publisher/CreatePublisherRequest.java
@@ -3,38 +3,30 @@ package no.sikt.nva.pubchannels.handler.create.publisher;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class CreatePublisherRequest {
+public record CreatePublisherRequest(@JsonProperty(NAME_FIELD) String name,
+                                     @JsonProperty(ISBN_PREFIX_FIELD) String isbnPrefix,
+                                     @JsonProperty(HOMEPAGE_FIELD) String homepage) {
 
     private static final String NAME_FIELD = "name";
     private static final String ISBN_PREFIX_FIELD = "isbnPrefix";
     private static final String HOMEPAGE_FIELD = "homepage";
 
-    @JsonProperty(NAME_FIELD)
-    private final String name;
-    @JsonProperty(ISBN_PREFIX_FIELD)
-    private final String isbnPrefix;
-    @JsonProperty(HOMEPAGE_FIELD)
-    private final String homepage;
-
     @JsonCreator
-    public CreatePublisherRequest(
-        @JsonProperty(NAME_FIELD) String name,
-        @JsonProperty(ISBN_PREFIX_FIELD) String isbnPrefix,
-        @JsonProperty(HOMEPAGE_FIELD) String homepage) {
-        this.name = name;
-        this.isbnPrefix = isbnPrefix;
-        this.homepage = homepage;
+    public CreatePublisherRequest {
     }
 
-    public String getName() {
+    @Override
+    public String name() {
         return name;
     }
 
-    public String getIsbnPrefix() {
+    @Override
+    public String isbnPrefix() {
         return isbnPrefix;
     }
 
-    public String getHomepage() {
+    @Override
+    public String homepage() {
         return homepage;
     }
 }

--- a/src/main/java/no/sikt/nva/pubchannels/handler/create/series/CreateSeriesHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/create/series/CreateSeriesHandler.java
@@ -4,7 +4,6 @@ import static no.sikt.nva.pubchannels.dataporten.ChannelType.SERIES;
 import static no.sikt.nva.pubchannels.handler.validator.Validator.validateOptionalIssn;
 import static no.sikt.nva.pubchannels.handler.validator.Validator.validateOptionalUrl;
 import static no.sikt.nva.pubchannels.handler.validator.Validator.validateString;
-import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import java.util.Map;
 import no.sikt.nva.pubchannels.HttpHeaders;
@@ -12,6 +11,7 @@ import no.sikt.nva.pubchannels.dataporten.DataportenPublicationChannelClient;
 import no.sikt.nva.pubchannels.dataporten.model.create.DataportenCreateSeriesRequest;
 import no.sikt.nva.pubchannels.handler.ThirdPartySeries;
 import no.sikt.nva.pubchannels.handler.create.CreateHandler;
+import no.sikt.nva.pubchannels.handler.validator.ValidationException;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.BadRequestException;
@@ -32,33 +32,39 @@ public class CreateSeriesHandler extends CreateHandler<CreateSeriesRequest, Crea
     }
 
     @Override
-    protected CreateSeriesResponse processInput(CreateSeriesRequest input, RequestInfo requestInfo, Context context)
+    protected void validateRequest(CreateSeriesRequest createSeriesRequest, RequestInfo requestInfo, Context context)
         throws ApiGatewayException {
         userIsAuthorizedToCreate(requestInfo);
-        var validInput = attempt(() -> validate(input))
-                             .map(CreateSeriesHandler::getClientRequest)
-                             .orElseThrow(failure -> new BadRequestException(failure.getException().getMessage()));
-        var createResponse = publicationChannelClient.createSeries(validInput);
-        var createdUri = constructIdUri(SERIES_PATH_ELEMENT, createResponse.getPid());
+        validate(createSeriesRequest);
+    }
+
+    @Override
+    protected CreateSeriesResponse processInput(CreateSeriesRequest input, RequestInfo requestInfo, Context context)
+        throws ApiGatewayException {
+        var response = publicationChannelClient.createSeries(getClientRequest(input));
+        var createdUri = constructIdUri(SERIES_PATH_ELEMENT, response.getPid());
         addAdditionalHeaders(() -> Map.of(HttpHeaders.LOCATION, createdUri.toString()));
         return CreateSeriesResponse.create(
             createdUri,
-            (ThirdPartySeries) publicationChannelClient.getChannel(SERIES, createResponse.getPid(), getYear()));
+            (ThirdPartySeries) publicationChannelClient.getChannel(SERIES, response.getPid(), getYear()));
     }
 
     private static DataportenCreateSeriesRequest getClientRequest(CreateSeriesRequest request) {
         return new DataportenCreateSeriesRequest(
-            request.getName(),
-            request.getPrintIssn(),
-            request.getOnlineIssn(),
-            request.getHomepage());
+            request.name(),
+            request.printIssn(),
+            request.onlineIssn(),
+            request.homepage());
     }
 
-    private CreateSeriesRequest validate(CreateSeriesRequest input) {
-        validateString(input.getName(), 5, 300, "Name");
-        validateOptionalIssn(input.getPrintIssn(), "PrintIssn");
-        validateOptionalIssn(input.getOnlineIssn(), "OnlineIssn");
-        validateOptionalUrl(input.getHomepage(), "Homepage");
-        return input;
+    private void validate(CreateSeriesRequest input) throws BadRequestException {
+        try {
+            validateString(input.name(), 5, 300, "Name");
+            validateOptionalIssn(input.printIssn(), "PrintIssn");
+            validateOptionalIssn(input.onlineIssn(), "OnlineIssn");
+            validateOptionalUrl(input.homepage(), "Homepage");
+        } catch (ValidationException exception) {
+            throw new BadRequestException(exception.getMessage());
+        }
     }
 }

--- a/src/main/java/no/sikt/nva/pubchannels/handler/create/series/CreateSeriesRequest.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/create/series/CreateSeriesRequest.java
@@ -3,46 +3,37 @@ package no.sikt.nva.pubchannels.handler.create.series;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class CreateSeriesRequest {
+public record CreateSeriesRequest(@JsonProperty(NAME_FIELD) String name,
+                                  @JsonProperty(PRINT_ISSN_FIELD) String printIssn,
+                                  @JsonProperty(ONLINE_ISSN_FIELD) String onlineIssn,
+                                  @JsonProperty(HOMEPAGE_FIELD) String homepage) {
+
     private static final String NAME_FIELD = "name";
     private static final String PRINT_ISSN_FIELD = "printIssn";
     private static final String ONLINE_ISSN_FIELD = "onlineIssn";
     private static final String HOMEPAGE_FIELD = "homepage";
 
-    @JsonProperty(NAME_FIELD)
-    private final String name;
-    @JsonProperty(PRINT_ISSN_FIELD)
-    private final String printIssn;
-    @JsonProperty(ONLINE_ISSN_FIELD)
-    private final String onlineIssn;
-    @JsonProperty(HOMEPAGE_FIELD)
-    private final String homepage;
-
     @JsonCreator
-    public CreateSeriesRequest(
-            @JsonProperty(NAME_FIELD) String name,
-            @JsonProperty(PRINT_ISSN_FIELD) String printIssn,
-            @JsonProperty(ONLINE_ISSN_FIELD) String onlineIssn,
-            @JsonProperty(HOMEPAGE_FIELD) String homepage) {
-        this.name = name;
-        this.printIssn = printIssn;
-        this.onlineIssn = onlineIssn;
-        this.homepage = homepage;
+    public CreateSeriesRequest {
     }
 
-    public String getName() {
+    @Override
+    public String name() {
         return name;
     }
 
-    public String getPrintIssn() {
+    @Override
+    public String printIssn() {
         return printIssn;
     }
 
-    public String getOnlineIssn() {
+    @Override
+    public String onlineIssn() {
         return onlineIssn;
     }
 
-    public String getHomepage() {
+    @Override
+    public String homepage() {
         return homepage;
     }
 }

--- a/src/main/java/no/sikt/nva/pubchannels/handler/create/series/CreateSeriesRequest.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/create/series/CreateSeriesRequest.java
@@ -1,39 +1,8 @@
 package no.sikt.nva.pubchannels.handler.create.series;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+public record CreateSeriesRequest(String name,
+                                  String printIssn,
+                                  String onlineIssn,
+                                  String homepage) {
 
-public record CreateSeriesRequest(@JsonProperty(NAME_FIELD) String name,
-                                  @JsonProperty(PRINT_ISSN_FIELD) String printIssn,
-                                  @JsonProperty(ONLINE_ISSN_FIELD) String onlineIssn,
-                                  @JsonProperty(HOMEPAGE_FIELD) String homepage) {
-
-    private static final String NAME_FIELD = "name";
-    private static final String PRINT_ISSN_FIELD = "printIssn";
-    private static final String ONLINE_ISSN_FIELD = "onlineIssn";
-    private static final String HOMEPAGE_FIELD = "homepage";
-
-    @JsonCreator
-    public CreateSeriesRequest {
-    }
-
-    @Override
-    public String name() {
-        return name;
-    }
-
-    @Override
-    public String printIssn() {
-        return printIssn;
-    }
-
-    @Override
-    public String onlineIssn() {
-        return onlineIssn;
-    }
-
-    @Override
-    public String homepage() {
-        return homepage;
-    }
 }

--- a/src/main/java/no/sikt/nva/pubchannels/handler/fetch/FetchByIdentifierAndYearHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/fetch/FetchByIdentifierAndYearHandler.java
@@ -4,7 +4,9 @@ import static com.google.common.net.MediaType.JSON_UTF_8;
 import static no.sikt.nva.pubchannels.handler.validator.Validator.validateUuid;
 import static no.sikt.nva.pubchannels.handler.validator.Validator.validateYear;
 import static nva.commons.apigateway.MediaTypes.APPLICATION_JSON_LD;
+import static nva.commons.core.attempt.Try.attempt;
 import static nva.commons.core.paths.UriWrapper.HTTPS;
+import com.amazonaws.services.lambda.runtime.Context;
 import com.google.common.net.MediaType;
 import java.net.HttpURLConnection;
 import java.net.URI;
@@ -14,6 +16,8 @@ import no.sikt.nva.pubchannels.dataporten.DataportenPublicationChannelClient;
 import no.sikt.nva.pubchannels.handler.PublicationChannelClient;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
+import nva.commons.apigateway.exceptions.ApiGatewayException;
+import nva.commons.apigateway.exceptions.BadRequestException;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.paths.UriWrapper;
@@ -67,6 +71,12 @@ public abstract class FetchByIdentifierAndYearHandler<I, O> extends ApiGatewayHa
             JSON_UTF_8,
             APPLICATION_JSON_LD
         );
+    }
+
+    @Override
+    protected void validateRequest(I input, RequestInfo requestInfo, Context context) throws ApiGatewayException {
+        attempt(() -> validate(requestInfo)).orElseThrow(
+            failure -> new BadRequestException(failure.getException().getMessage()));
     }
 
     @Override

--- a/src/main/java/no/sikt/nva/pubchannels/handler/fetch/journal/FetchJournalByIdentifierAndYearHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/fetch/journal/FetchJournalByIdentifierAndYearHandler.java
@@ -1,6 +1,5 @@
 package no.sikt.nva.pubchannels.handler.fetch.journal;
 
-import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import no.sikt.nva.pubchannels.dataporten.ChannelType;
 import no.sikt.nva.pubchannels.dataporten.PublicationChannelMovedException;
@@ -10,7 +9,6 @@ import no.sikt.nva.pubchannels.handler.ThirdPartyPublicationChannel;
 import no.sikt.nva.pubchannels.handler.fetch.FetchByIdentifierAndYearHandler;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
-import nva.commons.apigateway.exceptions.BadRequestException;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 
@@ -33,10 +31,7 @@ public class FetchJournalByIdentifierAndYearHandler extends
     protected FetchByIdAndYearResponse processInput(Void input, RequestInfo requestInfo, Context context)
         throws ApiGatewayException {
 
-        var request = attempt(() -> validate(requestInfo))
-                          .map(FetchByIdAndYearRequest::new)
-                          .orElseThrow(fail -> new BadRequestException(fail.getException().getMessage()));
-
+        var request = new FetchByIdAndYearRequest(requestInfo);
         var journalIdBaseUri = constructPublicationChannelIdBaseUri(JOURNAL_PATH_ELEMENT);
 
         var requestYear = request.getYear();

--- a/src/main/java/no/sikt/nva/pubchannels/handler/fetch/publisher/FetchPublisherByIdentifierAndYearHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/fetch/publisher/FetchPublisherByIdentifierAndYearHandler.java
@@ -1,7 +1,6 @@
 package no.sikt.nva.pubchannels.handler.fetch.publisher;
 
 import static no.sikt.nva.pubchannels.dataporten.ChannelType.PUBLISHER;
-import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import no.sikt.nva.pubchannels.dataporten.PublicationChannelMovedException;
 import no.sikt.nva.pubchannels.handler.PublicationChannelClient;
@@ -10,7 +9,6 @@ import no.sikt.nva.pubchannels.handler.ThirdPartyPublisher;
 import no.sikt.nva.pubchannels.handler.fetch.FetchByIdentifierAndYearHandler;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
-import nva.commons.apigateway.exceptions.BadRequestException;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 
@@ -33,10 +31,7 @@ public class FetchPublisherByIdentifierAndYearHandler extends
     protected FetchByIdAndYearResponse processInput(Void input, RequestInfo requestInfo,
                                                     Context context)
         throws ApiGatewayException {
-        var request = attempt(() -> validate(requestInfo))
-                          .map(FetchByIdAndYearRequest::new)
-                          .orElseThrow(fail -> new BadRequestException(fail.getException().getMessage()));
-
+        var request = new FetchByIdAndYearRequest(requestInfo);
         var publisherIdBaseUri = constructPublicationChannelIdBaseUri(PUBLISHER_PATH_ELEMENT);
 
         var requestYear = request.getYear();

--- a/src/main/java/no/sikt/nva/pubchannels/handler/fetch/series/FetchSeriesByIdentifierAndYearHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/fetch/series/FetchSeriesByIdentifierAndYearHandler.java
@@ -1,7 +1,6 @@
 package no.sikt.nva.pubchannels.handler.fetch.series;
 
 import static no.sikt.nva.pubchannels.dataporten.ChannelType.SERIES;
-import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import no.sikt.nva.pubchannels.dataporten.PublicationChannelMovedException;
 import no.sikt.nva.pubchannels.handler.PublicationChannelClient;
@@ -10,7 +9,6 @@ import no.sikt.nva.pubchannels.handler.ThirdPartySeries;
 import no.sikt.nva.pubchannels.handler.fetch.FetchByIdentifierAndYearHandler;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
-import nva.commons.apigateway.exceptions.BadRequestException;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 
@@ -32,10 +30,7 @@ public class FetchSeriesByIdentifierAndYearHandler extends
     @Override
     protected FetchByIdAndYearResponse processInput(Void input, RequestInfo requestInfo, Context context)
         throws ApiGatewayException {
-        var request = attempt(() -> validate(requestInfo))
-                          .map(FetchByIdAndYearRequest::new)
-                          .orElseThrow(fail -> new BadRequestException(fail.getException().getMessage()));
-
+        var request = new FetchByIdAndYearRequest(requestInfo);
         var publisherIdBaseUri = constructPublicationChannelIdBaseUri(SERIES_PATH_ELEMENT);
 
         var requestYear = request.getYear();

--- a/src/main/java/no/sikt/nva/pubchannels/handler/search/SearchByQueryHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/search/SearchByQueryHandler.java
@@ -73,6 +73,11 @@ public abstract class SearchByQueryHandler<T> extends ApiGatewayHandler<Void, Pa
     }
 
     @Override
+    protected void validateRequest(Void unused, RequestInfo requestInfo, Context context) throws ApiGatewayException {
+
+    }
+
+    @Override
     protected PaginatedSearchResult<T> processInput(Void input, RequestInfo requestInfo,
                                                     Context context) throws ApiGatewayException {
         var year = requestInfo.getQueryParameter(YEAR_QUERY_PARAM);

--- a/src/main/java/no/sikt/nva/pubchannels/handler/search/SearchByQueryHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/search/SearchByQueryHandler.java
@@ -34,11 +34,7 @@ public abstract class SearchByQueryHandler<T> extends ApiGatewayHandler<Void, Pa
 
     private static final String ENV_API_DOMAIN = "API_DOMAIN";
     private static final String ENV_CUSTOM_DOMAIN_BASE_PATH = "CUSTOM_DOMAIN_BASE_PATH";
-    private static final String QUERY_SIZE_PARAM = "size";
-    private static final String QUERY_OFFSET_PARAM = "offset";
     private static final String ISSN_QUERY_PARAM = "issn";
-    private static final int DEFAULT_QUERY_SIZE = 10;
-    private static final int DEFAULT_OFFSET_SIZE = 0;
     private static final String YEAR_QUERY_PARAM = "year";
     private static final String QUERY_PARAM = "query";
     private static final String NAME_QUERY_PARAM = "name";
@@ -74,29 +70,22 @@ public abstract class SearchByQueryHandler<T> extends ApiGatewayHandler<Void, Pa
 
     @Override
     protected void validateRequest(Void unused, RequestInfo requestInfo, Context context) throws ApiGatewayException {
-
+        validate(requestInfo);
     }
 
     @Override
     protected PaginatedSearchResult<T> processInput(Void input, RequestInfo requestInfo,
                                                     Context context) throws ApiGatewayException {
-        var year = requestInfo.getQueryParameter(YEAR_QUERY_PARAM);
-        var query = requestInfo.getQueryParameter(QUERY_PARAM);
-        int offset = requestInfo.getQueryParameterOpt(QUERY_OFFSET_PARAM).map(Integer::parseInt)
-                         .orElse(DEFAULT_OFFSET_SIZE);
-        int size = requestInfo.getQueryParameterOpt(QUERY_SIZE_PARAM).map(Integer::parseInt).orElse(DEFAULT_QUERY_SIZE);
-
-        validate(year, query, offset, size);
-
-        var searchResult = searchChannel(year, query, offset, size);
+        var searchParameters = SearchParameters.fromRequestInfo(requestInfo);
+        var searchResult = searchChannel(searchParameters);
 
         return PaginatedSearchResult.create(
             constructBaseUri(),
-            offset,
-            size,
+            searchParameters.offset(),
+            searchParameters.size(),
             searchResult.getPageInformation().getTotalResults(),
-            getHits(constructBaseUri(), searchResult, year),
-            Map.of(QUERY_PARAM, query, YEAR_QUERY_PARAM, year)
+            getHits(constructBaseUri(), searchResult, searchParameters.year()),
+            Map.of(QUERY_PARAM, searchParameters.query(), YEAR_QUERY_PARAM, searchParameters.year())
         );
     }
 
@@ -115,18 +104,19 @@ public abstract class SearchByQueryHandler<T> extends ApiGatewayHandler<Void, Pa
                    .getUri();
     }
 
-    private void validate(String year, String query, int offset, int size) throws BadRequestException {
+    private void validate(RequestInfo requestInfo) throws BadRequestException {
         attempt(() -> {
-            validateYear(year, Year.of(1900), "Year");
-            validateString(query, 4, 300, "Query");
-            validatePagination(offset, size);
+            var parameters = SearchParameters.fromRequestInfo(requestInfo);
+            validateYear(parameters.year(), Year.of(1900), "Year");
+            validateString(parameters.query(), 4, 300, "Query");
+            validatePagination(parameters.offset(), parameters.size());
             return null;
         }).orElseThrow(fail -> new BadRequestException(fail.getException().getMessage()));
     }
 
-    private ThirdPartySearchResponse searchChannel(String year, String query, int offset, int size)
+    private ThirdPartySearchResponse searchChannel(SearchParameters searchParameters)
         throws ApiGatewayException {
-        var queryParams = getQueryParams(year, query, offset, size);
+        var queryParams = getQueryParams(searchParameters);
         return publicationChannelClient.searchChannel(channelType, queryParams);
     }
 
@@ -138,18 +128,19 @@ public abstract class SearchByQueryHandler<T> extends ApiGatewayHandler<Void, Pa
                    .collect(Collectors.toList());
     }
 
-    private Map<String, String> getQueryParams(String year, String query, int offset, int size) {
+    private Map<String, String> getQueryParams(SearchParameters parameters) {
         var queryParams = new HashMap<String, String>();
-        queryParams.put(YEAR_QUERY_PARAM, year);
+        queryParams.put(YEAR_QUERY_PARAM, parameters.year());
 
+        var query = parameters.query();
         if (isQueryParameterIssn(query)) {
             queryParams.put(ISSN_QUERY_PARAM, query.trim());
         } else {
             queryParams.put(NAME_QUERY_PARAM, query.trim());
         }
 
-        queryParams.put(PAGENO_QUERY_PARAM, String.valueOf(offset / size));
-        queryParams.put(PAGECOUNT_QUERY_PARAM, String.valueOf(size));
+        queryParams.put(PAGENO_QUERY_PARAM, String.valueOf(parameters.offset() / parameters.size()));
+        queryParams.put(PAGECOUNT_QUERY_PARAM, String.valueOf(parameters.size()));
         return queryParams;
     }
 

--- a/src/main/java/no/sikt/nva/pubchannels/handler/search/SearchParameters.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/search/SearchParameters.java
@@ -1,0 +1,23 @@
+package no.sikt.nva.pubchannels.handler.search;
+
+import nva.commons.apigateway.RequestInfo;
+import nva.commons.apigateway.exceptions.BadRequestException;
+
+public record SearchParameters(String query, int offset, int size, String year) {
+
+    private static final int DEFAULT_QUERY_SIZE = 10;
+    private static final int DEFAULT_OFFSET_SIZE = 0;
+    private static final String QUERY_SIZE_PARAM = "size";
+    private static final String QUERY_OFFSET_PARAM = "offset";
+    private static final String YEAR_QUERY_PARAM = "year";
+    private static final String QUERY_PARAM = "query";
+
+    public static SearchParameters fromRequestInfo(RequestInfo requestInfo) throws BadRequestException {
+        return new SearchParameters(
+            requestInfo.getQueryParameter(QUERY_PARAM),
+            requestInfo.getQueryParameterOpt(QUERY_OFFSET_PARAM).map(Integer::parseInt).orElse(DEFAULT_OFFSET_SIZE),
+            requestInfo.getQueryParameterOpt(QUERY_SIZE_PARAM).map(Integer::parseInt).orElse(DEFAULT_QUERY_SIZE),
+            requestInfo.getQueryParameter(YEAR_QUERY_PARAM)
+        );
+    }
+}

--- a/src/test/java/no/sikt/nva/pubchannels/handler/create/journal/CreateJournalRequestTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/create/journal/CreateJournalRequestTest.java
@@ -1,0 +1,22 @@
+package no.sikt.nva.pubchannels.handler.create.journal;
+
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import no.unit.nva.commons.json.JsonUtils;
+import org.junit.jupiter.api.Test;
+
+class CreateJournalRequestTest {
+
+    @Test
+    void shouldBeAbleToRoundTripRecordViaJackson() throws JsonProcessingException {
+        var createJournalRequest = new CreateJournalRequest(randomString(), randomString(), randomString(),
+                                                            randomString());
+        var createJournalRequestString = JsonUtils.dtoObjectMapper.writeValueAsString(createJournalRequest);
+        var createJournalRequestRoundTripped = JsonUtils.dtoObjectMapper.readValue(createJournalRequestString,
+                                                                                   CreateJournalRequest.class);
+        assertThat(createJournalRequestRoundTripped, is(equalTo(createJournalRequest)));
+    }
+}

--- a/src/test/java/no/sikt/nva/pubchannels/handler/create/publisher/CreatePublisherRequestTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/create/publisher/CreatePublisherRequestTest.java
@@ -1,0 +1,21 @@
+package no.sikt.nva.pubchannels.handler.create.publisher;
+
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import no.unit.nva.commons.json.JsonUtils;
+import org.junit.jupiter.api.Test;
+
+class CreatePublisherRequestTest {
+
+    @Test
+    void shouldBeAbleToRoundTripRecordViaJackson() throws JsonProcessingException {
+        var createPublisherRequest = new CreatePublisherRequest(randomString(), randomString(), randomString());
+        var createPublisherRequestString = JsonUtils.dtoObjectMapper.writeValueAsString(createPublisherRequest);
+        var createPublisherRequestRoundTripped = JsonUtils.dtoObjectMapper.readValue(createPublisherRequestString,
+                                                                                     CreatePublisherRequest.class);
+        assertThat(createPublisherRequestRoundTripped, is(equalTo(createPublisherRequest)));
+    }
+}

--- a/src/test/java/no/sikt/nva/pubchannels/handler/create/series/CreateSeriesRequestTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/create/series/CreateSeriesRequestTest.java
@@ -1,0 +1,22 @@
+package no.sikt.nva.pubchannels.handler.create.series;
+
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import no.unit.nva.commons.json.JsonUtils;
+import org.junit.jupiter.api.Test;
+
+class CreateSeriesRequestTest {
+
+    @Test
+    void shouldBeAbleToRoundTripRecordViaJackson() throws JsonProcessingException {
+        var createSeriesRequest = new CreateSeriesRequest(randomString(), randomString(), randomString(),
+                                                          randomString());
+        var createSeriesRequestString = JsonUtils.dtoObjectMapper.writeValueAsString(createSeriesRequest);
+        var createSeriesRequestRoundTripped = JsonUtils.dtoObjectMapper.readValue(createSeriesRequestString,
+                                                                                  CreateSeriesRequest.class);
+        assertThat(createSeriesRequestRoundTripped, is(equalTo(createSeriesRequest)));
+    }
+}


### PR DESCRIPTION
_NP-47133 Search publication channel, too many search results when query contains ampersand_

- Updating commons to get bug fix for ampersands in query parameter values not being escaped
- Implement abstract method from commons `RestRequestHandler`: `validateRequest`
- Converted some classes to records