### PR TITLE
fix: Include year in response

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -585,6 +585,9 @@ components:
           description: The ISSN of the print edition of the Journal
         scientificValue:
           $ref: '#/components/schemas/ScientificValue'
+        year:
+          type: string
+          nullable: true
         sameAs:
           type: string
           nullable: true
@@ -648,6 +651,9 @@ components:
           pattern: ^(?:97(8|9)-)?[0-9]{1,5}-[0-9]{1,7}$
         scientificValue:
           $ref: '#/components/schemas/ScientificValue'
+        year:
+          type: string
+          nullable: true
         sameAs:
           type: string
           nullable: true
@@ -711,6 +717,9 @@ components:
           description: The ISSN of the print edition of the Series
         scientificValue:
           $ref: '#/components/schemas/ScientificValue'
+        year:
+          type: string
+          nullable: true
         sameAs:
           type: string
           nullable: true
@@ -799,6 +808,7 @@ components:
         onlineIssn: '1234-1234'
         printIssn: '4321-4321'
         scientificValue: 'LEVEL_1'
+        year: '1900'
         sameAs: 'https://kanalregister.hkdir.no/publiseringskanaler/KanalTidsskriftInfo?pid=151f411d-68cd-4c7a-9cbb-daf00e0326ce'
       summary: A sample journal
     CreateJournalExample:
@@ -837,6 +847,7 @@ components:
         name: 'The publisher of eternal fury'
         isbnPrefix: '12345-1234567'
         scientificValue: 'LEVEL_1'
+        year: '1900'
         sameAs: 'https://kanalregister.hkdir.no/publiseringskanaler/KanalTidsskriftInfo?pid=151f411d-68cd-4c7a-9cbb-daf00e0326ce'
       summary: A sample publisher
     PaginatedSeriesExample:
@@ -863,6 +874,7 @@ components:
         onlineIssn: '1234-1234'
         printIssn: '4321-4321'
         scientificValue: 'LEVEL_1'
+        year: '1900'
         sameAs: 'https://kanalregister.hkdir.no/publiseringskanaler/KanalTidsskriftInfo?pid=151f411d-68cd-4c7a-9cbb-daf00e0326ce'
       summary: A sample series
     CreateSeriesExample:

--- a/src/main/java/no/sikt/nva/pubchannels/handler/fetch/journal/FetchByIdAndYearRequest.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/fetch/journal/FetchByIdAndYearRequest.java
@@ -3,6 +3,7 @@ package no.sikt.nva.pubchannels.handler.fetch.journal;
 import nva.commons.apigateway.RequestInfo;
 
 public final class FetchByIdAndYearRequest {
+
     private static final String IDENTIFIER_PATH_PARAM_NAME = "identifier";
     private static final String YEAR_PATH_PARAM_NAME = "year";
 

--- a/src/main/java/no/sikt/nva/pubchannels/handler/fetch/journal/FetchJournalByIdentifierAndYearHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/fetch/journal/FetchJournalByIdentifierAndYearHandler.java
@@ -13,8 +13,7 @@ import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 
-public class FetchJournalByIdentifierAndYearHandler extends
-                                                    FetchByIdentifierAndYearHandler<Void, JournalDto> {
+public class FetchJournalByIdentifierAndYearHandler extends FetchByIdentifierAndYearHandler<Void, JournalDto> {
 
     private static final String JOURNAL_PATH_ELEMENT = "journal";
 
@@ -29,8 +28,7 @@ public class FetchJournalByIdentifierAndYearHandler extends
     }
 
     @Override
-    protected JournalDto processInput(Void input, RequestInfo requestInfo, Context context)
-        throws ApiGatewayException {
+    protected JournalDto processInput(Void input, RequestInfo requestInfo, Context context) throws ApiGatewayException {
 
         var request = new FetchByIdAndYearRequest(requestInfo);
         var journalIdBaseUri = constructPublicationChannelIdBaseUri(JOURNAL_PATH_ELEMENT);
@@ -45,8 +43,10 @@ public class FetchJournalByIdentifierAndYearHandler extends
         try {
             return publicationChannelClient.getChannel(ChannelType.JOURNAL, request.getIdentifier(), requestYear);
         } catch (PublicationChannelMovedException movedException) {
-            throw new PublicationChannelMovedException(
-                "Journal moved", constructNewLocation(JOURNAL_PATH_ELEMENT, movedException.getLocation(), requestYear));
+            throw new PublicationChannelMovedException("Journal moved",
+                                                       constructNewLocation(JOURNAL_PATH_ELEMENT,
+                                                                            movedException.getLocation(),
+                                                                            requestYear));
         }
     }
 }

--- a/src/main/java/no/sikt/nva/pubchannels/handler/fetch/series/FetchSeriesByIdentifierAndYearHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/fetch/series/FetchSeriesByIdentifierAndYearHandler.java
@@ -13,8 +13,7 @@ import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 
-public class FetchSeriesByIdentifierAndYearHandler extends
-                                                   FetchByIdentifierAndYearHandler<Void, SeriesDto> {
+public class FetchSeriesByIdentifierAndYearHandler extends FetchByIdentifierAndYearHandler<Void, SeriesDto> {
 
     private static final String SERIES_PATH_ELEMENT = "series";
 
@@ -29,8 +28,7 @@ public class FetchSeriesByIdentifierAndYearHandler extends
     }
 
     @Override
-    protected SeriesDto processInput(Void input, RequestInfo requestInfo, Context context)
-        throws ApiGatewayException {
+    protected SeriesDto processInput(Void input, RequestInfo requestInfo, Context context) throws ApiGatewayException {
         var request = new FetchByIdAndYearRequest(requestInfo);
         var publisherIdBaseUri = constructPublicationChannelIdBaseUri(SERIES_PATH_ELEMENT);
 
@@ -44,9 +42,10 @@ public class FetchSeriesByIdentifierAndYearHandler extends
         try {
             return publicationChannelClient.getChannel(SERIES, request.getIdentifier(), requestYear);
         } catch (PublicationChannelMovedException movedException) {
-            throw new PublicationChannelMovedException(
-                "Series moved",
-                constructNewLocation(SERIES_PATH_ELEMENT, movedException.getLocation(), requestYear));
+            throw new PublicationChannelMovedException("Series moved",
+                                                       constructNewLocation(SERIES_PATH_ELEMENT,
+                                                                            movedException.getLocation(),
+                                                                            requestYear));
         }
     }
 }

--- a/src/main/java/no/sikt/nva/pubchannels/handler/model/JournalDto.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/model/JournalDto.java
@@ -24,6 +24,8 @@ public class JournalDto implements JsonSerializable {
     private static final String SCIENTIFIC_VALUE_FIELD = "scientificValue";
     private static final String SAME_AS_FIELD = "sameAs";
     private static final String DISCONTINUED_FIELD = "discontinued";
+    private static final String YEAR_FIELD = "year";
+
     @JsonProperty(TYPE_FIELD)
     private static final String type = "Journal";
     @JsonProperty(CONTEXT_FIELD)
@@ -44,6 +46,8 @@ public class JournalDto implements JsonSerializable {
     private final URI sameAs;
     @JsonProperty(DISCONTINUED_FIELD)
     private final String discontinued;
+    @JsonProperty(YEAR_FIELD)
+    private final String year;
 
     @JsonCreator
     public JournalDto(@JsonProperty(ID_FIELD) URI id,
@@ -53,7 +57,8 @@ public class JournalDto implements JsonSerializable {
                       @JsonProperty(PRINT_ISSN_FIELD) String printIssn,
                       @JsonProperty(SCIENTIFIC_VALUE_FIELD) ScientificValue scientificValue,
                       @JsonProperty(SAME_AS_FIELD) URI sameAs,
-                      @JsonProperty(DISCONTINUED_FIELD) String discontinued) {
+                      @JsonProperty(DISCONTINUED_FIELD) String discontinued,
+                      @JsonProperty(YEAR_FIELD) String year) {
         this.id = id;
         this.identifier = identifier;
         this.name = name;
@@ -62,13 +67,12 @@ public class JournalDto implements JsonSerializable {
         this.scientificValue = scientificValue;
         this.sameAs = sameAs;
         this.discontinued = discontinued;
+        this.year = year;
     }
 
     public static JournalDto create(URI selfUriBase, ThirdPartyJournal journal, String requestedYear) {
         var year = Optional.ofNullable(journal.getYear()).orElse(requestedYear);
-        var id = UriWrapper.fromUri(selfUriBase)
-                     .addChild(journal.identifier(), year)
-                     .getUri();
+        var id = UriWrapper.fromUri(selfUriBase).addChild(journal.identifier(), year).getUri();
         return new JournalDto(id,
                               journal.identifier(),
                               journal.name(),
@@ -76,7 +80,8 @@ public class JournalDto implements JsonSerializable {
                               journal.printIssn(),
                               journal.getScientificValue(),
                               journal.homepage(),
-                              journal.discontinued());
+                              journal.discontinued(),
+                              year);
     }
 
     public String getType() {
@@ -115,11 +120,23 @@ public class JournalDto implements JsonSerializable {
         return sameAs;
     }
 
+    public String getYear() {
+        return year;
+    }
+
     @Override
     @JacocoGenerated
     public int hashCode() {
-        return Objects.hash(context, id, identifier, name, onlineIssn, printIssn, scientificValue, sameAs,
-                            discontinued);
+        return Objects.hash(context,
+                            id,
+                            identifier,
+                            name,
+                            onlineIssn,
+                            printIssn,
+                            scientificValue,
+                            sameAs,
+                            discontinued,
+                            year);
     }
 
     @Override
@@ -134,13 +151,15 @@ public class JournalDto implements JsonSerializable {
         JournalDto that = (JournalDto) o;
         return Objects.equals(context, that.context)
                && Objects.equals(id, that.id)
-               && Objects.equals(identifier, that.identifier)
+               && Objects.equals(identifier,
+                                 that.identifier)
                && Objects.equals(name, that.name)
                && Objects.equals(onlineIssn, that.onlineIssn)
                && Objects.equals(printIssn, that.printIssn)
                && scientificValue == that.scientificValue
                && Objects.equals(sameAs, that.sameAs)
-               && Objects.equals(discontinued, that.discontinued);
+               && Objects.equals(discontinued, that.discontinued)
+               && Objects.equals(year, that.year);
     }
 
     @Override

--- a/src/main/java/no/sikt/nva/pubchannels/handler/model/PublisherDto.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/model/PublisherDto.java
@@ -23,6 +23,8 @@ public class PublisherDto implements JsonSerializable {
     private static final String SCIENTIFIC_VALUE_FIELD = "scientificValue";
     private static final String SAME_AS_FIELD = "sameAs";
     private static final String DISCONTINUED_FIELD = "discontinued";
+    private static final String YEAR_FIELD = "year";
+
     @JsonProperty(TYPE_FIELD)
     private static final String TYPE = "Publisher";
     @JsonProperty(CONTEXT_FIELD)
@@ -41,6 +43,8 @@ public class PublisherDto implements JsonSerializable {
     private final URI sameAs;
     @JsonProperty(DISCONTINUED_FIELD)
     private final String discontinued;
+    @JsonProperty(YEAR_FIELD)
+    private final String year;
 
     @JsonCreator
     public PublisherDto(@JsonProperty(ID_FIELD) URI id,
@@ -49,7 +53,7 @@ public class PublisherDto implements JsonSerializable {
                         @JsonProperty(ISBN_PREFIX_FIELD) String isbnPrefix,
                         @JsonProperty(SCIENTIFIC_VALUE_FIELD) ScientificValue scientificValue,
                         @JsonProperty(SAME_AS_FIELD) URI sameAs,
-                        @JsonProperty(DISCONTINUED_FIELD) String discontinued) {
+                        @JsonProperty(DISCONTINUED_FIELD) String discontinued, @JsonProperty(YEAR_FIELD) String year) {
         this.id = id;
         this.identifier = identifier;
         this.name = name;
@@ -57,21 +61,20 @@ public class PublisherDto implements JsonSerializable {
         this.scientificValue = scientificValue;
         this.sameAs = sameAs;
         this.discontinued = discontinued;
+        this.year = year;
     }
 
-    public static PublisherDto create(URI selfUriBase, ThirdPartyPublisher publisher,
-                                      String requestedYear) {
+    public static PublisherDto create(URI selfUriBase, ThirdPartyPublisher publisher, String requestedYear) {
         var year = Optional.ofNullable(publisher.getYear()).orElse(requestedYear);
-        var id = UriWrapper.fromUri(selfUriBase)
-                     .addChild(publisher.identifier(), year)
-                     .getUri();
+        var id = UriWrapper.fromUri(selfUriBase).addChild(publisher.identifier(), year).getUri();
         return new PublisherDto(id,
                                 publisher.identifier(),
                                 publisher.name(),
                                 publisher.isbnPrefix(),
                                 publisher.getScientificValue(),
                                 publisher.homepage(),
-                                publisher.discontinued());
+                                publisher.discontinued(),
+                                year);
     }
 
     public String getType() {
@@ -110,10 +113,14 @@ public class PublisherDto implements JsonSerializable {
         return discontinued;
     }
 
+    public String getYear() {
+        return year;
+    }
+
     @Override
     @JacocoGenerated
     public int hashCode() {
-        return Objects.hash(context, id, identifier, name, isbnPrefix, scientificValue, sameAs, discontinued);
+        return Objects.hash(context, id, identifier, name, isbnPrefix, scientificValue, sameAs, discontinued, year);
     }
 
     @Override
@@ -128,12 +135,14 @@ public class PublisherDto implements JsonSerializable {
         PublisherDto that = (PublisherDto) o;
         return Objects.equals(context, that.context)
                && Objects.equals(id, that.id)
-               && Objects.equals(identifier, that.identifier)
+               && Objects.equals(identifier,
+                                 that.identifier)
                && Objects.equals(name, that.name)
                && Objects.equals(isbnPrefix, that.isbnPrefix)
                && scientificValue == that.scientificValue
                && Objects.equals(sameAs, that.sameAs)
-               && Objects.equals(discontinued, that.discontinued);
+               && Objects.equals(discontinued, that.discontinued)
+               && Objects.equals(year, that.year);
     }
 }
 

--- a/src/main/java/no/sikt/nva/pubchannels/handler/model/SeriesDto.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/model/SeriesDto.java
@@ -24,6 +24,7 @@ public class SeriesDto implements JsonSerializable {
     private static final String SCIENTIFIC_VALUE_FIELD = "scientificValue";
     private static final String SAME_AS_FIELD = "sameAs";
     private static final String DISCONTINUED_FIELD = "discontinued";
+    private static final String YEAR_FIELD = "year";
 
     @JsonProperty(TYPE_FIELD)
     private static final String TYPE = "Series";
@@ -45,6 +46,8 @@ public class SeriesDto implements JsonSerializable {
     private final URI sameAs;
     @JsonProperty(DISCONTINUED_FIELD)
     private final String discontinued;
+    @JsonProperty(YEAR_FIELD)
+    private final String year;
 
     @JsonCreator
     public SeriesDto(@JsonProperty(ID_FIELD) URI id,
@@ -54,7 +57,8 @@ public class SeriesDto implements JsonSerializable {
                      @JsonProperty(PRINT_ISSN_FIELD) String printIssn,
                      @JsonProperty(SCIENTIFIC_VALUE_FIELD) ScientificValue scientificValue,
                      @JsonProperty(SAME_AS_FIELD) URI sameAs,
-                     @JsonProperty(DISCONTINUED_FIELD) String discontinued) {
+                     @JsonProperty(DISCONTINUED_FIELD) String discontinued,
+                     @JsonProperty(YEAR_FIELD) String year) {
         this.id = id;
         this.identifier = identifier;
         this.name = name;
@@ -63,13 +67,12 @@ public class SeriesDto implements JsonSerializable {
         this.scientificValue = scientificValue;
         this.sameAs = sameAs;
         this.discontinued = discontinued;
+        this.year = year;
     }
 
     public static SeriesDto create(URI selfUriBase, ThirdPartySeries series, String requestedYear) {
         var year = Optional.ofNullable(series.getYear()).orElse(requestedYear);
-        var id = UriWrapper.fromUri(selfUriBase)
-                     .addChild(series.identifier(), year)
-                     .getUri();
+        var id = UriWrapper.fromUri(selfUriBase).addChild(series.identifier(), year).getUri();
         return new SeriesDto(id,
                              series.identifier(),
                              series.name(),
@@ -77,7 +80,8 @@ public class SeriesDto implements JsonSerializable {
                              series.printIssn(),
                              series.getScientificValue(),
                              series.homepage(),
-                             series.discontinued());
+                             series.discontinued(),
+                             year);
     }
 
     public String getType() {
@@ -120,10 +124,21 @@ public class SeriesDto implements JsonSerializable {
         return discontinued;
     }
 
+    public String getYear() {
+        return year;
+    }
+
     @Override
     @JacocoGenerated
     public int hashCode() {
-        return Objects.hash(context, id, identifier, name, onlineIssn, printIssn, scientificValue, sameAs,
+        return Objects.hash(context,
+                            id,
+                            identifier,
+                            name,
+                            onlineIssn,
+                            printIssn,
+                            scientificValue,
+                            sameAs,
                             discontinued);
     }
 
@@ -139,7 +154,8 @@ public class SeriesDto implements JsonSerializable {
         SeriesDto that = (SeriesDto) o;
         return Objects.equals(context, that.context)
                && Objects.equals(id, that.id)
-               && Objects.equals(identifier, that.identifier)
+               && Objects.equals(identifier,
+                                 that.identifier)
                && Objects.equals(name, that.name)
                && Objects.equals(onlineIssn, that.onlineIssn)
                && Objects.equals(printIssn, that.printIssn)

--- a/src/main/java/no/sikt/nva/pubchannels/handler/model/SeriesDto.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/model/SeriesDto.java
@@ -139,7 +139,8 @@ public class SeriesDto implements JsonSerializable {
                             printIssn,
                             scientificValue,
                             sameAs,
-                            discontinued);
+                            discontinued,
+                            year);
     }
 
     @Override
@@ -161,7 +162,8 @@ public class SeriesDto implements JsonSerializable {
                && Objects.equals(printIssn, that.printIssn)
                && scientificValue == that.scientificValue
                && Objects.equals(sameAs, that.sameAs)
-               && Objects.equals(discontinued, that.discontinued);
+               && Objects.equals(discontinued, that.discontinued)
+               && Objects.equals(year, that.year);
     }
 
     @Override

--- a/src/test/java/no/sikt/nva/pubchannels/handler/fetch/journal/FetchJournalByIdentifierAndYearHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/fetch/journal/FetchJournalByIdentifierAndYearHandlerTest.java
@@ -124,15 +124,12 @@ class FetchJournalByIdentifierAndYearHandlerTest {
 
     @Test
     void shouldIncludeYearInResponse() throws IOException {
-        // Arrange
         var year = TestUtils.randomYear();
         var identifier = mockRegistry.randomJournal(year);
         var input = constructRequest(String.valueOf(year), identifier);
 
-        // Act
         handlerUnderTest.handleRequest(input, output, context);
 
-        // Assert
         var response = GatewayResponse.fromOutputStream(output, JournalDto.class);
         var actualYear = response.getBodyObject(JournalDto.class).getYear();
         assertThat(actualYear, is(equalTo(String.valueOf(year))));

--- a/src/test/java/no/sikt/nva/pubchannels/handler/fetch/publisher/FetchPublisherByIdentifierAndYearHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/fetch/publisher/FetchPublisherByIdentifierAndYearHandlerTest.java
@@ -108,16 +108,13 @@ class FetchPublisherByIdentifierAndYearHandlerTest {
 
     @Test
     void shouldIncludeYearInResponse() throws IOException {
-        // Arrange
         var year = randomYear();
         var identifier = UUID.randomUUID().toString();
         var input = constructRequest(String.valueOf(year), identifier, MediaType.ANY_TYPE);
         mockPublisherFound(year, identifier);
 
-        // Act
         handlerUnderTest.handleRequest(input, output, context);
 
-        // Assert
         var response = GatewayResponse.fromOutputStream(output, PublisherDto.class);
         var actualYear = response.getBodyObject(PublisherDto.class).getYear();
         assertThat(actualYear, is(equalTo(String.valueOf(year))));

--- a/src/test/java/no/sikt/nva/pubchannels/handler/fetch/series/FetchSeriesByIdentifierAndYearHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/fetch/series/FetchSeriesByIdentifierAndYearHandlerTest.java
@@ -107,16 +107,13 @@ class FetchSeriesByIdentifierAndYearHandlerTest {
 
     @Test
     void shouldIncludeYearInResponse() throws IOException {
-        // Arrange
         var year = randomYear();
         var identifier = UUID.randomUUID().toString();
         var input = constructRequest(String.valueOf(year), identifier, MediaType.ANY_TYPE);
         mockSeriesFound(year, identifier);
 
-        // Act
         handlerUnderTest.handleRequest(input, output, context);
 
-        // Assert
         var response = GatewayResponse.fromOutputStream(output, SeriesDto.class);
         var actualYear = response.getBodyObject(SeriesDto.class).getYear();
         assertThat(actualYear, is(equalTo(String.valueOf(year))));


### PR DESCRIPTION
Includes the "year" field in responses when fetching Journal, Publisher and Series, which was previously omitted. Note that if the external API does not include this, the field value is taken from the request instead.