### PR TITLE
feat: Make  year optional query parameter

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -97,7 +97,7 @@ paths:
         type: "AWS_PROXY"
       tags:
         - Journal
-      summary: Search for journal by pid, name or issn and year
+      summary: Search for journal by pid, name, issn, or year
       description: Returns a list of Journals
       operationId: SearchJournalByQuery
       parameters:
@@ -106,7 +106,7 @@ paths:
           schema:
             type: integer
           description: The year you want the NVI for
-          required: true
+          required: false
         - in: query
           name: query
           schema:
@@ -258,7 +258,7 @@ paths:
         type: "AWS_PROXY"
       tags:
         - Publisher
-      summary: Search for publisher by pid, name or issn and year
+      summary: Search for publisher by pid, name, issn, or year
       description: Returns a list of Publishers
       operationId: SearchPublisherByQuery
       parameters:
@@ -267,7 +267,7 @@ paths:
           schema:
             type: integer
           description: The year you want the NVI for
-          required: true
+          required: false
         - in: query
           name: query
           schema:
@@ -419,7 +419,7 @@ paths:
         type: "AWS_PROXY"
       tags:
         - Series
-      summary: Search for series by pid, name or issn and year
+      summary: Search for series by pid, name, issn, or year
       description: Returns a list of Series
       operationId: SearchSeriesByQuery
       parameters:
@@ -428,7 +428,7 @@ paths:
           schema:
             type: integer
           description: The year you want the NVI for
-          required: true
+          required: false
         - in: query
           name: query
           schema:

--- a/src/main/java/no/sikt/nva/pubchannels/channelregistry/ChannelRegistryClient.java
+++ b/src/main/java/no/sikt/nva/pubchannels/channelregistry/ChannelRegistryClient.java
@@ -121,7 +121,7 @@ public class ChannelRegistryClient implements PublicationChannelClient {
             throw new BadRequestException(response.body());
         }
         if (HTTP_MOVED_PERM == statusCode) {
-            var location = response.headers().map().get("Location").get(0);
+            var location = response.headers().map().get("Location").getFirst();
             LOGGER.info("Publication channel moved permanently to: {}", location);
             throw new PublicationChannelMovedException("Publication channel moved permanently!", URI.create(location));
         }

--- a/src/main/java/no/sikt/nva/pubchannels/handler/create/CreateHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/create/CreateHandler.java
@@ -6,8 +6,8 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.time.Year;
-import no.sikt.nva.pubchannels.dataporten.DataportenAuthClient;
 import no.sikt.nva.pubchannels.channelregistry.ChannelRegistryClient;
+import no.sikt.nva.pubchannels.dataporten.DataportenAuthClient;
 import no.sikt.nva.pubchannels.handler.PublicationChannelClient;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
@@ -24,7 +24,7 @@ public abstract class CreateHandler<I, O> extends ApiGatewayHandler<I, O> {
     private static final String ENV_CUSTOM_DOMAIN_BASE_PATH = "CUSTOM_DOMAIN_BASE_PATH";
     private static final String SECRET_NAME = "DataportenChannelRegistryClientCredentials";
     private static final String CURRENT_YEAR = Year.now().toString();
-    protected PublicationChannelClient publicationChannelClient;
+    protected final PublicationChannelClient publicationChannelClient;
 
     @JacocoGenerated
     protected CreateHandler(Class<I> iclass, Environment environment) {

--- a/src/main/java/no/sikt/nva/pubchannels/handler/fetch/FetchByIdentifierAndYearHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/fetch/FetchByIdentifierAndYearHandler.java
@@ -28,7 +28,7 @@ public abstract class FetchByIdentifierAndYearHandler<I, O> extends ApiGatewayHa
     private static final String ENV_CUSTOM_DOMAIN_BASE_PATH = "CUSTOM_DOMAIN_BASE_PATH";
     private static final String YEAR_PATH_PARAM_NAME = "year";
     private static final String IDENTIFIER_PATH_PARAM_NAME = "identifier";
-    protected PublicationChannelClient publicationChannelClient;
+    protected final PublicationChannelClient publicationChannelClient;
 
     @JacocoGenerated
     protected FetchByIdentifierAndYearHandler(Class<I> iclass, Environment environment) {

--- a/src/main/java/no/sikt/nva/pubchannels/handler/search/SearchByQueryHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/search/SearchByQueryHandler.java
@@ -79,10 +79,12 @@ public abstract class SearchByQueryHandler<T> extends ApiGatewayHandler<Void, Pa
         var searchParameters = SearchParameters.fromRequestInfo(requestInfo);
         var searchResult = searchChannel(searchParameters);
 
-        // Create query params for pagination, with offset and size handled separately
-        var baseQueryParameters = getQueryParams(searchParameters);
-        baseQueryParameters.remove(PAGENO_QUERY_PARAM);
-        baseQueryParameters.remove(PAGECOUNT_QUERY_PARAM);
+        // Create map of query parameters excluding the pagination parameters (offset and size)
+        var baseQueryParameters = new HashMap<String, String>();
+        baseQueryParameters.put(QUERY_PARAM, searchParameters.query());
+        if (searchParameters.year() != null) {
+            baseQueryParameters.put(YEAR_QUERY_PARAM, searchParameters.year());
+        }
 
         return PaginatedSearchResult.create(
             constructBaseUri(),

--- a/src/main/java/no/sikt/nva/pubchannels/handler/search/SearchByQueryHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/search/SearchByQueryHandler.java
@@ -16,8 +16,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import no.sikt.nva.pubchannels.channelregistry.ChannelType;
 import no.sikt.nva.pubchannels.channelregistry.ChannelRegistryClient;
+import no.sikt.nva.pubchannels.channelregistry.ChannelType;
 import no.sikt.nva.pubchannels.handler.PublicationChannelClient;
 import no.sikt.nva.pubchannels.handler.ThirdPartyPublicationChannel;
 import no.unit.nva.commons.pagination.PaginatedSearchResult;
@@ -79,13 +79,18 @@ public abstract class SearchByQueryHandler<T> extends ApiGatewayHandler<Void, Pa
         var searchParameters = SearchParameters.fromRequestInfo(requestInfo);
         var searchResult = searchChannel(searchParameters);
 
+        // Create query params for pagination, with offset and size handled separately
+        var baseQueryParameters = getQueryParams(searchParameters);
+        baseQueryParameters.remove(PAGENO_QUERY_PARAM);
+        baseQueryParameters.remove(PAGECOUNT_QUERY_PARAM);
+
         return PaginatedSearchResult.create(
             constructBaseUri(),
             searchParameters.offset(),
             searchParameters.size(),
             searchResult.pageInformation().totalResults(),
             getHits(constructBaseUri(), searchResult, searchParameters.year()),
-            Map.of(QUERY_PARAM, searchParameters.query(), YEAR_QUERY_PARAM, searchParameters.year())
+            baseQueryParameters
         );
     }
 
@@ -130,9 +135,12 @@ public abstract class SearchByQueryHandler<T> extends ApiGatewayHandler<Void, Pa
 
     private Map<String, String> getQueryParams(SearchParameters parameters) {
         var queryParams = new HashMap<String, String>();
-        queryParams.put(YEAR_QUERY_PARAM, parameters.year());
-
         var query = parameters.query();
+
+        if (parameters.year() != null) {
+            queryParams.put(YEAR_QUERY_PARAM, parameters.year());
+        }
+
         if (isQueryParameterIssn(query)) {
             queryParams.put(ISSN_QUERY_PARAM, query.trim());
         } else {

--- a/src/main/java/no/sikt/nva/pubchannels/handler/search/SearchParameters.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/search/SearchParameters.java
@@ -17,7 +17,7 @@ public record SearchParameters(String query, int offset, int size, String year) 
             requestInfo.getQueryParameter(QUERY_PARAM),
             requestInfo.getQueryParameterOpt(QUERY_OFFSET_PARAM).map(Integer::parseInt).orElse(DEFAULT_OFFSET_SIZE),
             requestInfo.getQueryParameterOpt(QUERY_SIZE_PARAM).map(Integer::parseInt).orElse(DEFAULT_QUERY_SIZE),
-            requestInfo.getQueryParameter(YEAR_QUERY_PARAM)
+            requestInfo.getQueryParameterOpt(YEAR_QUERY_PARAM).orElse(null)
         );
     }
 }

--- a/src/main/java/no/sikt/nva/pubchannels/handler/validator/Validator.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/validator/Validator.java
@@ -60,13 +60,17 @@ public final class Validator {
     }
 
     public static void validateYear(String value, Year minAcceptableYear, String name) {
-        Objects.requireNonNull(value, format(IS_REQUIRED_STRING, name));
-        var year = attempt(() -> Year.parse(value))
-                       .orElseThrow(failure -> new ValidationException(format("%s field is not a valid year.", name)));
-        var now = Year.now();
-        if (year.isBefore(minAcceptableYear) || year.isAfter(now.plusYears(1))) {
-            throw new ValidationException(
-                format("%s is not between the year %d and %d", name, minAcceptableYear.getValue(), now.getValue()));
+        if (value != null) {
+            var year = attempt(() -> Year.parse(value)).orElseThrow(failure -> new ValidationException(format(
+                "%s field is not a valid year.",
+                name)));
+            var now = Year.now();
+            if (year.isBefore(minAcceptableYear) || year.isAfter(now.plusYears(1))) {
+                throw new ValidationException(format("%s is not between the year %d and %d",
+                                                     name,
+                                                     minAcceptableYear.getValue(),
+                                                     now.getValue()));
+            }
         }
     }
 

--- a/src/test/java/no/sikt/nva/pubchannels/TestCommons.java
+++ b/src/test/java/no/sikt/nva/pubchannels/TestCommons.java
@@ -16,7 +16,9 @@ public class TestCommons {
     public static final int MAX_LEVEL = 2;
     public static final double MIN_LEVEL = 0;
     public static final String DEFAULT_OFFSET = "0";
+    public static final int DEFAULT_OFFSET_INT = 0;
     public static final String DEFAULT_SIZE = "10";
+    public static final int DEFAULT_SIZE_INT = 10;
     public static final String CHANNEL_REGISTRY_PAGE_NO_PARAM = "pageno";
     public static final String CHANNEL_REGISTRY_PAGE_COUNT_PARAM = "pagecount";
     public static final String WILD_CARD = "*";

--- a/src/test/java/no/sikt/nva/pubchannels/handler/TestUtils.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/TestUtils.java
@@ -130,7 +130,7 @@ public class TestUtils {
                    .collect(Collectors.toList());
     }
 
-    public static List<String> getChannelRegistrySearchPublisherResult(int year, String name, int maxNr) {
+    public static List<String> getChannelRegistrySearchPublisherResult(Integer year, String name, int maxNr) {
         return IntStream.range(0, maxNr)
                    .mapToObj(i -> createChannelRegistryPublisherResponse(year, name, UUID.randomUUID().toString(),
                                                                          String.valueOf(validIsbnPrefix()),

--- a/src/test/java/no/sikt/nva/pubchannels/handler/TestUtils.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/TestUtils.java
@@ -377,7 +377,7 @@ public class TestUtils {
         var entityResult = objectMapper.createObjectNode();
         var arrayNode = objectMapper.createArrayNode();
         results.forEach(arrayNode::add);
-        entityResult.put(PAGERESULT_FIELD, arrayNode);
+        entityResult.set(PAGERESULT_FIELD, arrayNode);
         return entityResult;
     }
 }

--- a/src/test/java/no/sikt/nva/pubchannels/handler/create/series/CreateSeriesRequestBuilder.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/create/series/CreateSeriesRequestBuilder.java
@@ -1,6 +1,5 @@
 package no.sikt.nva.pubchannels.handler.create.series;
 
-import no.sikt.nva.pubchannels.handler.create.publisher.CreatePublisherRequest;
 
 public class CreateSeriesRequestBuilder {
     private String name;

--- a/src/test/java/no/sikt/nva/pubchannels/handler/fetch/journal/SeriesDtoTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/fetch/journal/SeriesDtoTest.java
@@ -4,8 +4,6 @@ import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.net.URI;

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/journal/SearchJournalByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/journal/SearchJournalByQueryHandlerTest.java
@@ -18,7 +18,6 @@ import static no.sikt.nva.pubchannels.handler.TestUtils.constructPublicationChan
 import static no.sikt.nva.pubchannels.handler.TestUtils.createChannelRegistryJournalResponse;
 import static no.sikt.nva.pubchannels.handler.TestUtils.createJournal;
 import static no.sikt.nva.pubchannels.handler.TestUtils.getChannelRegistryResponseBody;
-import static no.sikt.nva.pubchannels.handler.TestUtils.getChannelRegistrySearchPublisherResult;
 import static no.sikt.nva.pubchannels.handler.TestUtils.getChannelRegistrySearchResult;
 import static no.sikt.nva.pubchannels.handler.TestUtils.getScientificValue;
 import static no.sikt.nva.pubchannels.handler.TestUtils.randomYear;
@@ -183,9 +182,9 @@ class SearchJournalByQueryHandlerTest {
 
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
         assertThat(pagesSearchResult.getTotalHits(), is(equalTo(channelRegistrySearchResult.size())));
-        var expectedSearchresult = getExpectedPaginatedSearchJournalResultNameSearch(
+        var expectedSearchResult = getExpectedPaginatedSearchJournalResultNameSearch(
             channelRegistrySearchResult, yearString, name, offset, size);
-        assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchresult.getHits().toArray()));
+        assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
     }
 
     @Test
@@ -196,7 +195,7 @@ class SearchJournalByQueryHandlerTest {
         int maxNr = 30;
         int offset = 0;
         int size = 10;
-        var result = getChannelRegistrySearchPublisherResult(year, name, maxNr);
+        var result = getChannelRegistrySearchResult(year, name, maxNr);
         var responseBody = getChannelRegistryResponseBody(result, offset, size);
         stubChannelRegistrySearchResponse(responseBody,
                                           HttpURLConnection.HTTP_OK,

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/journal/SearchJournalByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/journal/SearchJournalByQueryHandlerTest.java
@@ -18,6 +18,7 @@ import static no.sikt.nva.pubchannels.handler.TestUtils.constructPublicationChan
 import static no.sikt.nva.pubchannels.handler.TestUtils.createChannelRegistryJournalResponse;
 import static no.sikt.nva.pubchannels.handler.TestUtils.createJournal;
 import static no.sikt.nva.pubchannels.handler.TestUtils.getChannelRegistryResponseBody;
+import static no.sikt.nva.pubchannels.handler.TestUtils.getChannelRegistrySearchPublisherResult;
 import static no.sikt.nva.pubchannels.handler.TestUtils.getChannelRegistrySearchResult;
 import static no.sikt.nva.pubchannels.handler.TestUtils.getScientificValue;
 import static no.sikt.nva.pubchannels.handler.TestUtils.randomYear;
@@ -188,6 +189,41 @@ class SearchJournalByQueryHandlerTest {
     }
 
     @Test
+    void shouldReturnResultWithSuccessWhenQueryOmitsYear() throws IOException, UnprocessableContentException {
+        var year = randomYear();
+        var yearString = String.valueOf(year);
+        var name = randomString();
+        int maxNr = 30;
+        int offset = 0;
+        int size = 10;
+        var result = getChannelRegistrySearchPublisherResult(year, name, maxNr);
+        var responseBody = getChannelRegistryResponseBody(result, offset, size);
+        stubChannelRegistrySearchResponse(responseBody,
+                                          HttpURLConnection.HTTP_OK,
+                                          CHANNEL_REGISTRY_PAGE_COUNT_PARAM,
+                                          DEFAULT_SIZE,
+                                          CHANNEL_REGISTRY_PAGE_NO_PARAM,
+                                          DEFAULT_OFFSET,
+                                          NAME_QUERY_PARAM,
+                                          name);
+        var input = constructRequest(Map.of("query", name), MediaType.ANY_TYPE);
+
+        handlerUnderTest.handleRequest(input, output, context);
+
+        var response = GatewayResponse.fromOutputStream(output, PaginatedSearchResult.class);
+        var pagesSearchResult = objectMapper.readValue(response.getBody(), TYPE_REF);
+
+        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
+        assertThat(pagesSearchResult.getTotalHits(), is(equalTo(result.size())));
+        var expectedSearchResult = getExpectedPaginatedSearchJournalResultNameSearch(result,
+                                                                                     yearString,
+                                                                                     name,
+                                                                                     offset,
+                                                                                     size);
+        assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
+    }
+
+    @Test
     void shouldReturnResultWithSuccessWhenQueryIsNameAndOffsetIs10() throws IOException, UnprocessableContentException {
         var year = randomYear();
         var yearString = String.valueOf(year);
@@ -235,21 +271,6 @@ class SearchJournalByQueryHandlerTest {
         var problem = response.getBodyObject(Problem.class);
 
         assertThat(problem.getDetail(), is(containsString("Year")));
-    }
-
-    @Test
-    void shouldReturnBadRequestWhenMissingQueryParamYear() throws IOException {
-        var input = constructRequest(Map.of("query", randomString()), MediaType.ANY_TYPE);
-
-        this.handlerUnderTest.handleRequest(input, output, context);
-
-        var response = GatewayResponse.fromOutputStream(output, Problem.class);
-
-        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_BAD_REQUEST)));
-
-        var problem = response.getBodyObject(Problem.class);
-
-        assertThat(problem.getDetail(), is(containsString("year")));
     }
 
     @Test

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/journal/SearchJournalByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/journal/SearchJournalByQueryHandlerTest.java
@@ -8,7 +8,9 @@ import static no.sikt.nva.pubchannels.HttpHeaders.CONTENT_TYPE;
 import static no.sikt.nva.pubchannels.TestCommons.CHANNEL_REGISTRY_PAGE_COUNT_PARAM;
 import static no.sikt.nva.pubchannels.TestCommons.CHANNEL_REGISTRY_PAGE_NO_PARAM;
 import static no.sikt.nva.pubchannels.TestCommons.DEFAULT_OFFSET;
+import static no.sikt.nva.pubchannels.TestCommons.DEFAULT_OFFSET_INT;
 import static no.sikt.nva.pubchannels.TestCommons.DEFAULT_SIZE;
+import static no.sikt.nva.pubchannels.TestCommons.DEFAULT_SIZE_INT;
 import static no.sikt.nva.pubchannels.TestCommons.ISSN_QUERY_PARAM;
 import static no.sikt.nva.pubchannels.TestCommons.MAX_LEVEL;
 import static no.sikt.nva.pubchannels.TestCommons.MIN_LEVEL;
@@ -29,6 +31,7 @@ import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static nva.commons.core.attempt.Try.attempt;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.StringContains.containsString;
@@ -119,6 +122,7 @@ class SearchJournalByQueryHandlerTest {
         var contentType = response.getHeaders().get(CONTENT_TYPE);
         assertThat(contentType, is(equalTo(expectedMediaType)));
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
+        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test
@@ -136,6 +140,7 @@ class SearchJournalByQueryHandlerTest {
 
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
+        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test
@@ -154,6 +159,7 @@ class SearchJournalByQueryHandlerTest {
 
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
+        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test
@@ -185,12 +191,12 @@ class SearchJournalByQueryHandlerTest {
         var expectedSearchResult = getExpectedPaginatedSearchJournalResultNameSearch(
             channelRegistrySearchResult, yearString, name, offset, size);
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
+        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test
     void shouldReturnResultWithSuccessWhenQueryOmitsYear() throws IOException, UnprocessableContentException {
         var year = randomYear();
-        var yearString = String.valueOf(year);
         var name = randomString();
         int maxNr = 30;
         int offset = 0;
@@ -214,12 +220,12 @@ class SearchJournalByQueryHandlerTest {
 
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
         assertThat(pagesSearchResult.getTotalHits(), is(equalTo(result.size())));
-        var expectedSearchResult = getExpectedPaginatedSearchJournalResultNameSearch(result,
-                                                                                     yearString,
+        var expectedSearchResult = getExpectedPaginatedSearchJournalResultNameSearch(result, null,
                                                                                      name,
                                                                                      offset,
                                                                                      size);
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
+        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test
@@ -250,9 +256,10 @@ class SearchJournalByQueryHandlerTest {
 
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
         assertThat(pagesSearchResult.getTotalHits(), is(equalTo(channelRegistrySearchResult.size())));
-        var expectedSearchresult = getExpectedPaginatedSearchJournalResultNameSearch(
+        var expectedSearchResult = getExpectedPaginatedSearchJournalResultNameSearch(
             channelRegistrySearchResult, yearString, name, offset, size);
-        assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchresult.getHits().toArray()));
+        assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
+        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @ParameterizedTest(name = "year {0} is invalid")
@@ -379,21 +386,28 @@ class SearchJournalByQueryHandlerTest {
         return Stream.of(" ", "abcd", yearAfterNextYear, "21000");
     }
 
-    private static PaginatedSearchResult<JournalDto> getExpectedPaginatedSearchJournalResultNameSearch(
-        List<String> channelRegistryResults,
-        String year,
-        String name, int queryOffset, int querySize)
+    private static PaginatedSearchResult<JournalDto> getExpectedPaginatedSearchJournalResultNameSearch(List<String> channelRegistryResults,
+                                                                                                       String year,
+                                                                                                       String name,
+                                                                                                       int queryOffset,
+                                                                                                       int querySize)
         throws UnprocessableContentException {
         var expectedHits = mapToJournalResults(channelRegistryResults, year);
+        var expectedParams = new HashMap<String, String>();
+        expectedParams.put("query", name);
+        if (year != null) {
+            expectedParams.put("year", year);
+        }
 
-        return PaginatedSearchResult.create(
-            constructPublicationChannelUri(JOURNAL_PATH_ELEMENT, Map.of("year", year, "query", name)),
-            queryOffset,
-            querySize,
-            expectedHits.size(),
-            expectedHits.stream().skip(queryOffset).limit(querySize).collect(Collectors.toList()),
-            Map.of("year", year, "query", name,
-                   "offset", String.valueOf(queryOffset), "size", String.valueOf(querySize)));
+        return PaginatedSearchResult.create(constructPublicationChannelUri(JOURNAL_PATH_ELEMENT, null),
+                                            queryOffset,
+                                            querySize,
+                                            expectedHits.size(),
+                                            expectedHits.stream()
+                                                        .skip(queryOffset)
+                                                        .limit(querySize)
+                                                        .collect(Collectors.toList()),
+                                            expectedParams);
     }
 
     private static List<JournalDto> mapToJournalResults(List<String> channelRegistryResults, String requestedYear) {
@@ -467,23 +481,28 @@ class SearchJournalByQueryHandlerTest {
         URI landingPage,
         String discontinued) throws UnprocessableContentException {
 
-        var expectedHits = List.of(
-            JournalDto.create(
-                constructPublicationChannelUri(JOURNAL_PATH_ELEMENT, null),
-                createJournal(year, pid, name, electronicIssn, printIssn, getScientificValue(level), landingPage,
-                              discontinued),
-                year
-            ));
+        var expectedHits = List.of(JournalDto.create(constructPublicationChannelUri(JOURNAL_PATH_ELEMENT, null),
+                                                     createJournal(year,
+                                                                   pid,
+                                                                   name,
+                                                                   electronicIssn,
+                                                                   printIssn,
+                                                                   getScientificValue(level),
+                                                                   landingPage,
+                                                                   discontinued),
+                                                     year));
 
-        return PaginatedSearchResult.create(
-            constructPublicationChannelUri(
-                JOURNAL_PATH_ELEMENT,
-                Map.of("year", year, "query", printIssn, "offset", DEFAULT_OFFSET, "size", DEFAULT_SIZE)
-            ),
-            0,
-            expectedHits.size(),
-            expectedHits.size(),
-            expectedHits);
+        var expectedParams = new HashMap<String, String>();
+        expectedParams.put("query", printIssn);
+        if (year != null) {
+            expectedParams.put("year", year);
+        }
+
+        return PaginatedSearchResult.create(constructPublicationChannelUri(JOURNAL_PATH_ELEMENT, expectedParams),
+                                            DEFAULT_OFFSET_INT,
+                                            DEFAULT_SIZE_INT,
+                                            expectedHits.size(),
+                                            expectedHits);
     }
 
     private String randomLevel() {

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/publisher/SearchPublisherByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/publisher/SearchPublisherByQueryHandlerTest.java
@@ -8,7 +8,9 @@ import static no.sikt.nva.pubchannels.HttpHeaders.CONTENT_TYPE;
 import static no.sikt.nva.pubchannels.TestCommons.CHANNEL_REGISTRY_PAGE_COUNT_PARAM;
 import static no.sikt.nva.pubchannels.TestCommons.CHANNEL_REGISTRY_PAGE_NO_PARAM;
 import static no.sikt.nva.pubchannels.TestCommons.DEFAULT_OFFSET;
+import static no.sikt.nva.pubchannels.TestCommons.DEFAULT_OFFSET_INT;
 import static no.sikt.nva.pubchannels.TestCommons.DEFAULT_SIZE;
+import static no.sikt.nva.pubchannels.TestCommons.DEFAULT_SIZE_INT;
 import static no.sikt.nva.pubchannels.TestCommons.ISSN_QUERY_PARAM;
 import static no.sikt.nva.pubchannels.TestCommons.MAX_LEVEL;
 import static no.sikt.nva.pubchannels.TestCommons.MIN_LEVEL;
@@ -29,6 +31,7 @@ import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static nva.commons.core.attempt.Try.attempt;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.StringContains.containsString;
@@ -119,6 +122,7 @@ class SearchPublisherByQueryHandlerTest {
         var contentType = response.getHeaders().get(CONTENT_TYPE);
         assertThat(contentType, is(equalTo(expectedMediaType)));
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
+        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test
@@ -137,6 +141,7 @@ class SearchPublisherByQueryHandlerTest {
 
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
+        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test
@@ -156,6 +161,7 @@ class SearchPublisherByQueryHandlerTest {
 
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
+        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test
@@ -184,15 +190,15 @@ class SearchPublisherByQueryHandlerTest {
 
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
         assertThat(pagesSearchResult.getTotalHits(), is(equalTo(result.size())));
-        var expectedSearchresult = getExpectedPaginatedSearchPublisherResultNameSearch(
+        var expectedSearchResult = getExpectedPaginatedSearchPublisherResultNameSearch(
             result, yearString, name, offset, size);
-        assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchresult.getHits().toArray()));
+        assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
+        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test
     void shouldReturnResultWithSuccessWhenQueryOmitsYear() throws IOException, UnprocessableContentException {
         var year = randomYear();
-        var yearString = String.valueOf(year);
         var name = randomString();
         int maxNr = 30;
         int offset = 0;
@@ -216,12 +222,12 @@ class SearchPublisherByQueryHandlerTest {
 
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
         assertThat(pagesSearchResult.getTotalHits(), is(equalTo(result.size())));
-        var expectedSearchResult = getExpectedPaginatedSearchPublisherResultNameSearch(result,
-                                                                                       yearString,
+        var expectedSearchResult = getExpectedPaginatedSearchPublisherResultNameSearch(result, null,
                                                                                        name,
                                                                                        offset,
                                                                                        size);
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
+        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test
@@ -255,6 +261,7 @@ class SearchPublisherByQueryHandlerTest {
         var expectedSearchResult = getExpectedPaginatedSearchPublisherResultNameSearch(
             result, yearString, name, offset, size);
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
+        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @ParameterizedTest(name = "year {0} is invalid")
@@ -381,21 +388,28 @@ class SearchPublisherByQueryHandlerTest {
         return Stream.of(" ", "abcd", yearAfterNextYear, "21000");
     }
 
-    private static PaginatedSearchResult<PublisherDto> getExpectedPaginatedSearchPublisherResultNameSearch(
-        List<String> results,
-        String year,
-        String name, int queryOffset, int querySize)
+    private static PaginatedSearchResult<PublisherDto> getExpectedPaginatedSearchPublisherResultNameSearch(List<String> results,
+                                                                                                           String year,
+                                                                                                           String name,
+                                                                                                           int queryOffset,
+                                                                                                           int querySize)
         throws UnprocessableContentException {
         var expectedHits = mapToPublisherResults(results, year);
+        var expectedParams = new HashMap<String, String>();
+        expectedParams.put("query", name);
+        if (year != null) {
+            expectedParams.put("year", year);
+        }
 
-        return PaginatedSearchResult.create(
-            constructPublicationChannelUri(PUBLISHER_PATH_ELEMENT, Map.of("year", year, "query", name)),
-            queryOffset,
-            querySize,
-            expectedHits.size(),
-            expectedHits.stream().skip(queryOffset).limit(querySize).collect(Collectors.toList()),
-            Map.of("year", year, "query", name,
-                   "offset", String.valueOf(queryOffset), "size", String.valueOf(querySize)));
+        return PaginatedSearchResult.create(constructPublicationChannelUri(PUBLISHER_PATH_ELEMENT, null),
+                                            queryOffset,
+                                            querySize,
+                                            expectedHits.size(),
+                                            expectedHits.stream()
+                                                        .skip(queryOffset)
+                                                        .limit(querySize)
+                                                        .collect(Collectors.toList()),
+                                            expectedParams);
     }
 
     private static List<PublisherDto> mapToPublisherResults(List<String> results, String requestedYear) {
@@ -469,21 +483,27 @@ class SearchPublisherByQueryHandlerTest {
         URI landingPage) throws UnprocessableContentException {
         var discontinued = String.valueOf(Integer.parseInt(String.valueOf(year)) - 1);
 
-        var expectedHits = List.of(
-            PublisherDto.create(
-                constructPublicationChannelUri(PUBLISHER_PATH_ELEMENT, null),
-                createPublisher(year, pid, name, isbnPrefix, getScientificValue(level), landingPage, discontinued), year
-            ));
+        var expectedHits = List.of(PublisherDto.create(constructPublicationChannelUri(PUBLISHER_PATH_ELEMENT, null),
+                                                       createPublisher(year,
+                                                                       pid,
+                                                                       name,
+                                                                       isbnPrefix,
+                                                                       getScientificValue(level),
+                                                                       landingPage,
+                                                                       discontinued),
+                                                       year));
 
-        return PaginatedSearchResult.create(
-            constructPublicationChannelUri(
-                PUBLISHER_PATH_ELEMENT,
-                Map.of("year", year, "query", printIssn, "offset", DEFAULT_OFFSET, "size", DEFAULT_SIZE)
-            ),
-            0,
-            expectedHits.size(),
-            expectedHits.size(),
-            expectedHits);
+        var expectedParams = new HashMap<String, String>();
+        expectedParams.put("query", printIssn);
+        if (year != null) {
+            expectedParams.put("year", year);
+        }
+
+        return PaginatedSearchResult.create(constructPublicationChannelUri(PUBLISHER_PATH_ELEMENT, expectedParams),
+                                            DEFAULT_OFFSET_INT,
+                                            DEFAULT_SIZE_INT,
+                                            expectedHits.size(),
+                                            expectedHits);
     }
 
     private String randomLevel() {

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/series/SearchSeriesByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/series/SearchSeriesByQueryHandlerTest.java
@@ -8,7 +8,9 @@ import static no.sikt.nva.pubchannels.HttpHeaders.CONTENT_TYPE;
 import static no.sikt.nva.pubchannels.TestCommons.CHANNEL_REGISTRY_PAGE_COUNT_PARAM;
 import static no.sikt.nva.pubchannels.TestCommons.CHANNEL_REGISTRY_PAGE_NO_PARAM;
 import static no.sikt.nva.pubchannels.TestCommons.DEFAULT_OFFSET;
+import static no.sikt.nva.pubchannels.TestCommons.DEFAULT_OFFSET_INT;
 import static no.sikt.nva.pubchannels.TestCommons.DEFAULT_SIZE;
+import static no.sikt.nva.pubchannels.TestCommons.DEFAULT_SIZE_INT;
 import static no.sikt.nva.pubchannels.TestCommons.ISSN_QUERY_PARAM;
 import static no.sikt.nva.pubchannels.TestCommons.NAME_QUERY_PARAM;
 import static no.sikt.nva.pubchannels.TestCommons.YEAR_QUERY_PARAM;
@@ -28,6 +30,7 @@ import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static nva.commons.core.attempt.Try.attempt;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.StringContains.containsString;
@@ -81,22 +84,28 @@ class SearchSeriesByQueryHandlerTest {
     private SearchSeriesByQueryHandler handlerUnderTest;
     private ByteArrayOutputStream output;
 
-    public static PaginatedSearchResult<SeriesDto> getExpectedPaginatedSearchResultNameSearch(
-        List<String> results,
-        String year,
-        String name, int queryOffset, int querySize)
+    public static PaginatedSearchResult<SeriesDto> getExpectedPaginatedSearchResultNameSearch(List<String> results,
+                                                                                              String year,
+                                                                                              String name,
+                                                                                              int queryOffset,
+                                                                                              int querySize)
         throws UnprocessableContentException {
-        var expectedHits =
-            mapToSeriesResults(results, year);
+        var expectedHits = mapToSeriesResults(results, year);
+        var expectedParams = new HashMap<String, String>();
+        expectedParams.put("query", name);
+        if (year != null) {
+            expectedParams.put("year", year);
+        }
 
-        return PaginatedSearchResult.create(
-            constructPublicationChannelUri(PATH_ELEMENT, Map.of("year", year, "query", name)),
-            queryOffset,
-            querySize,
-            expectedHits.size(),
-            expectedHits.stream().skip(queryOffset).limit(querySize).collect(Collectors.toList()),
-            Map.of("year", year, "query", name,
-                   "offset", String.valueOf(queryOffset), "size", String.valueOf(querySize)));
+        return PaginatedSearchResult.create(constructPublicationChannelUri(PATH_ELEMENT, null),
+                                            queryOffset,
+                                            querySize,
+                                            expectedHits.size(),
+                                            expectedHits.stream()
+                                                        .skip(queryOffset)
+                                                        .limit(querySize)
+                                                        .collect(Collectors.toList()),
+                                            expectedParams);
     }
 
     @BeforeEach
@@ -136,6 +145,7 @@ class SearchSeriesByQueryHandlerTest {
         var contentType = response.getHeaders().get(CONTENT_TYPE);
         assertThat(contentType, is(equalTo(expectedMediaType)));
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
+        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test
@@ -153,6 +163,7 @@ class SearchSeriesByQueryHandlerTest {
 
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
+        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test
@@ -171,6 +182,7 @@ class SearchSeriesByQueryHandlerTest {
 
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
+        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test
@@ -201,12 +213,12 @@ class SearchSeriesByQueryHandlerTest {
         var expectedSearchResult = getExpectedPaginatedSearchResultNameSearch(
             result, yearString, name, offset, size);
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
+        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test
     void shouldReturnResultWithSuccessWhenQueryOmitsYear() throws IOException, UnprocessableContentException {
         var year = randomYear();
-        var yearString = String.valueOf(year);
         var name = randomString();
         int maxNr = 30;
         int offset = 0;
@@ -230,8 +242,9 @@ class SearchSeriesByQueryHandlerTest {
 
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
         assertThat(pagesSearchResult.getTotalHits(), is(equalTo(result.size())));
-        var expectedSearchResult = getExpectedPaginatedSearchResultNameSearch(result, yearString, name, offset, size);
+        var expectedSearchResult = getExpectedPaginatedSearchResultNameSearch(result, null, name, offset, size);
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
+        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test
@@ -262,9 +275,10 @@ class SearchSeriesByQueryHandlerTest {
 
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
         assertThat(pagesSearchResult.getTotalHits(), is(equalTo(result.size())));
-        var expectedSearchresult = getExpectedPaginatedSearchResultNameSearch(result, yearString, name,
+        var expectedSearchResult = getExpectedPaginatedSearchResultNameSearch(result, yearString, name,
                                                                               offset, size);
-        assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchresult.getHits().toArray()));
+        assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
+        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @ParameterizedTest(name = "year {0} is invalid")
@@ -470,13 +484,12 @@ class SearchSeriesByQueryHandlerTest {
                              discontinued),
                 year));
 
-        return PaginatedSearchResult.create(
-            constructPublicationChannelUri(
-                PATH_ELEMENT, Map.of("year", year, "query", printIssn, "offset", DEFAULT_OFFSET, "size", DEFAULT_SIZE)),
-            0,
-            expectedHits.size(),
-            expectedHits.size(),
-            expectedHits);
+        return PaginatedSearchResult.create(constructPublicationChannelUri(PATH_ELEMENT,
+                                                                           Map.of("year", year, "query", printIssn)),
+                                            DEFAULT_OFFSET_INT,
+                                            DEFAULT_SIZE_INT,
+                                            expectedHits.size(),
+                                            expectedHits);
     }
 
     private void stubChannelRegistrySearchResponse(String body, int status, String... queryValue) {

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/series/SearchSeriesByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/series/SearchSeriesByQueryHandlerTest.java
@@ -16,7 +16,6 @@ import static no.sikt.nva.pubchannels.handler.TestUtils.constructPublicationChan
 import static no.sikt.nva.pubchannels.handler.TestUtils.createChannelRegistryJournalResponse;
 import static no.sikt.nva.pubchannels.handler.TestUtils.createSeries;
 import static no.sikt.nva.pubchannels.handler.TestUtils.getChannelRegistryResponseBody;
-import static no.sikt.nva.pubchannels.handler.TestUtils.getChannelRegistrySearchPublisherResult;
 import static no.sikt.nva.pubchannels.handler.TestUtils.getChannelRegistrySearchResult;
 import static no.sikt.nva.pubchannels.handler.TestUtils.getScientificValue;
 import static no.sikt.nva.pubchannels.handler.TestUtils.randomLevel;
@@ -212,7 +211,7 @@ class SearchSeriesByQueryHandlerTest {
         int maxNr = 30;
         int offset = 0;
         int size = 10;
-        var result = getChannelRegistrySearchPublisherResult(year, name, maxNr);
+        var result = getChannelRegistrySearchResult(year, name, maxNr);
         var responseBody = getChannelRegistryResponseBody(result, offset, size);
         stubChannelRegistrySearchResponse(responseBody,
                                           HttpURLConnection.HTTP_OK,


### PR DESCRIPTION
Makes the  query parameter `year` optional for journal, series, and publication searches.

Refs: https://sikt.atlassian.net/browse/NP-46251