### PR TITLE
[np-47567] Fix flaky tests

### DIFF
--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/journal/SearchJournalByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/journal/SearchJournalByQueryHandlerTest.java
@@ -3,6 +3,7 @@ package no.sikt.nva.pubchannels.handler.search.journal;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+
 import static no.sikt.nva.pubchannels.HttpHeaders.ACCEPT;
 import static no.sikt.nva.pubchannels.HttpHeaders.CONTENT_TYPE;
 import static no.sikt.nva.pubchannels.TestCommons.CHANNEL_REGISTRY_PAGE_COUNT_PARAM;
@@ -16,6 +17,7 @@ import static no.sikt.nva.pubchannels.TestCommons.MAX_LEVEL;
 import static no.sikt.nva.pubchannels.TestCommons.MIN_LEVEL;
 import static no.sikt.nva.pubchannels.TestCommons.NAME_QUERY_PARAM;
 import static no.sikt.nva.pubchannels.TestCommons.YEAR_QUERY_PARAM;
+import static no.sikt.nva.pubchannels.handler.TestUtils.areEqualURIs;
 import static no.sikt.nva.pubchannels.handler.TestUtils.constructPublicationChannelUri;
 import static no.sikt.nva.pubchannels.handler.TestUtils.createChannelRegistryJournalResponse;
 import static no.sikt.nva.pubchannels.handler.TestUtils.createJournal;
@@ -28,14 +30,18 @@ import static no.unit.nva.testutils.RandomDataGenerator.objectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.randomIssn;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
+
 import static nva.commons.core.attempt.Try.attempt;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.samePropertyValuesAs;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
+
 import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -44,6 +50,28 @@ import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.github.tomakehurst.wiremock.matching.StringValuePattern;
 import com.google.common.net.MediaType;
+
+import no.sikt.nva.pubchannels.channelregistry.ChannelRegistryClient;
+import no.sikt.nva.pubchannels.channelregistry.model.ChannelRegistryJournal;
+import no.sikt.nva.pubchannels.handler.ThirdPartyJournal;
+import no.sikt.nva.pubchannels.handler.model.JournalDto;
+import no.unit.nva.commons.pagination.PaginatedSearchResult;
+import no.unit.nva.stubs.FakeContext;
+import no.unit.nva.stubs.WiremockHttpClient;
+import no.unit.nva.testutils.HandlerRequestBuilder;
+
+import nva.commons.apigateway.GatewayResponse;
+import nva.commons.apigateway.exceptions.UnprocessableContentException;
+import nva.commons.core.Environment;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+import org.zalando.problem.Problem;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -56,24 +84,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import no.sikt.nva.pubchannels.channelregistry.ChannelRegistryClient;
-import no.sikt.nva.pubchannels.channelregistry.model.ChannelRegistryJournal;
-import no.sikt.nva.pubchannels.handler.ThirdPartyJournal;
-import no.sikt.nva.pubchannels.handler.model.JournalDto;
-import no.unit.nva.commons.pagination.PaginatedSearchResult;
-import no.unit.nva.stubs.FakeContext;
-import no.unit.nva.stubs.WiremockHttpClient;
-import no.unit.nva.testutils.HandlerRequestBuilder;
-import nva.commons.apigateway.GatewayResponse;
-import nva.commons.apigateway.exceptions.UnprocessableContentException;
-import nva.commons.core.Environment;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mockito;
-import org.zalando.problem.Problem;
 
 @WireMockTest(httpsEnabled = true)
 class SearchJournalByQueryHandlerTest {
@@ -260,6 +270,53 @@ class SearchJournalByQueryHandlerTest {
             channelRegistrySearchResult, yearString, name, offset, size);
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
         assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
+    }
+
+    @Test
+    void shouldReturnResultWithQueryAsId() throws IOException, UnprocessableContentException {
+        var year = randomYear();
+        var yearString = String.valueOf(year);
+        var name = randomString();
+        int offset = 10;
+        int size = 10;
+        int maxNr = 30;
+        var channelRegistrySearchResult = getChannelRegistrySearchResult(year, name, maxNr);
+        stubChannelRegistrySearchResponse(
+                getChannelRegistryResponseBody(channelRegistrySearchResult, offset, size),
+                HttpURLConnection.HTTP_OK,
+                YEAR_QUERY_PARAM,
+                yearString,
+                CHANNEL_REGISTRY_PAGE_COUNT_PARAM,
+                String.valueOf(size),
+                CHANNEL_REGISTRY_PAGE_NO_PARAM,
+                String.valueOf(offset / size),
+                NAME_QUERY_PARAM,
+                name);
+        var input =
+                constructRequest(
+                        Map.of(
+                                "year",
+                                yearString,
+                                "query",
+                                name,
+                                "offset",
+                                String.valueOf(offset),
+                                "size",
+                                String.valueOf(size)),
+                        MediaType.ANY_TYPE);
+
+        handlerUnderTest.handleRequest(input, output, context);
+
+        var response = GatewayResponse.fromOutputStream(output, PaginatedSearchResult.class);
+        var pagesSearchResult = objectMapper.readValue(response.getBody(), TYPE_REF);
+
+        var expectedSearchResult =
+                getExpectedPaginatedSearchJournalResultNameSearch(
+                        channelRegistrySearchResult, yearString, name, offset, size);
+        var expectedUri = expectedSearchResult.getId();
+        var actualUri = pagesSearchResult.getId();
+
+        assertTrue(areEqualURIs(actualUri, expectedUri));
     }
 
     @ParameterizedTest(name = "year {0} is invalid")

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/journal/SearchJournalByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/journal/SearchJournalByQueryHandlerTest.java
@@ -35,7 +35,6 @@ import static nva.commons.core.attempt.Try.attempt;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.samePropertyValuesAs;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.StringContains.containsString;
@@ -132,7 +131,6 @@ class SearchJournalByQueryHandlerTest {
         var contentType = response.getHeaders().get(CONTENT_TYPE);
         assertThat(contentType, is(equalTo(expectedMediaType)));
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
-        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test
@@ -150,7 +148,6 @@ class SearchJournalByQueryHandlerTest {
 
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
-        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test
@@ -169,7 +166,6 @@ class SearchJournalByQueryHandlerTest {
 
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
-        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test
@@ -201,7 +197,6 @@ class SearchJournalByQueryHandlerTest {
         var expectedSearchResult = getExpectedPaginatedSearchJournalResultNameSearch(
             channelRegistrySearchResult, yearString, name, offset, size);
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
-        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test
@@ -235,7 +230,6 @@ class SearchJournalByQueryHandlerTest {
                                                                                      offset,
                                                                                      size);
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
-        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test
@@ -269,7 +263,6 @@ class SearchJournalByQueryHandlerTest {
         var expectedSearchResult = getExpectedPaginatedSearchJournalResultNameSearch(
             channelRegistrySearchResult, yearString, name, offset, size);
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
-        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/publisher/SearchPublisherByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/publisher/SearchPublisherByQueryHandlerTest.java
@@ -3,6 +3,7 @@ package no.sikt.nva.pubchannels.handler.search.publisher;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+
 import static no.sikt.nva.pubchannels.HttpHeaders.ACCEPT;
 import static no.sikt.nva.pubchannels.HttpHeaders.CONTENT_TYPE;
 import static no.sikt.nva.pubchannels.TestCommons.CHANNEL_REGISTRY_PAGE_COUNT_PARAM;
@@ -16,6 +17,7 @@ import static no.sikt.nva.pubchannels.TestCommons.MAX_LEVEL;
 import static no.sikt.nva.pubchannels.TestCommons.MIN_LEVEL;
 import static no.sikt.nva.pubchannels.TestCommons.NAME_QUERY_PARAM;
 import static no.sikt.nva.pubchannels.TestCommons.YEAR_QUERY_PARAM;
+import static no.sikt.nva.pubchannels.handler.TestUtils.areEqualURIs;
 import static no.sikt.nva.pubchannels.handler.TestUtils.constructPublicationChannelUri;
 import static no.sikt.nva.pubchannels.handler.TestUtils.createChannelRegistryPublisherResponse;
 import static no.sikt.nva.pubchannels.handler.TestUtils.createPublisher;
@@ -28,14 +30,18 @@ import static no.unit.nva.testutils.RandomDataGenerator.objectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.randomIssn;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
+
 import static nva.commons.core.attempt.Try.attempt;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.samePropertyValuesAs;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
+
 import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -44,6 +50,28 @@ import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.github.tomakehurst.wiremock.matching.StringValuePattern;
 import com.google.common.net.MediaType;
+
+import no.sikt.nva.pubchannels.channelregistry.ChannelRegistryClient;
+import no.sikt.nva.pubchannels.channelregistry.model.ChannelRegistryPublisher;
+import no.sikt.nva.pubchannels.handler.ThirdPartyPublisher;
+import no.sikt.nva.pubchannels.handler.model.PublisherDto;
+import no.unit.nva.commons.pagination.PaginatedSearchResult;
+import no.unit.nva.stubs.FakeContext;
+import no.unit.nva.stubs.WiremockHttpClient;
+import no.unit.nva.testutils.HandlerRequestBuilder;
+
+import nva.commons.apigateway.GatewayResponse;
+import nva.commons.apigateway.exceptions.UnprocessableContentException;
+import nva.commons.core.Environment;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+import org.zalando.problem.Problem;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -56,24 +84,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import no.sikt.nva.pubchannels.channelregistry.ChannelRegistryClient;
-import no.sikt.nva.pubchannels.channelregistry.model.ChannelRegistryPublisher;
-import no.sikt.nva.pubchannels.handler.ThirdPartyPublisher;
-import no.sikt.nva.pubchannels.handler.model.PublisherDto;
-import no.unit.nva.commons.pagination.PaginatedSearchResult;
-import no.unit.nva.stubs.FakeContext;
-import no.unit.nva.stubs.WiremockHttpClient;
-import no.unit.nva.testutils.HandlerRequestBuilder;
-import nva.commons.apigateway.GatewayResponse;
-import nva.commons.apigateway.exceptions.UnprocessableContentException;
-import nva.commons.core.Environment;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mockito;
-import org.zalando.problem.Problem;
 
 @WireMockTest(httpsEnabled = true)
 class SearchPublisherByQueryHandlerTest {
@@ -262,6 +272,53 @@ class SearchPublisherByQueryHandlerTest {
             result, yearString, name, offset, size);
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
         assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
+    }
+
+    @Test
+    void shouldReturnResultWithQueryAsId() throws IOException, UnprocessableContentException {
+        var year = randomYear();
+        var yearString = String.valueOf(year);
+        var name = randomString();
+        int offset = 10;
+        int size = 10;
+        int maxNr = 30;
+        var result = getChannelRegistrySearchPublisherResult(year, name, maxNr);
+        stubChannelRegistrySearchResponse(
+                getChannelRegistryResponseBody(result, offset, size),
+                HttpURLConnection.HTTP_OK,
+                YEAR_QUERY_PARAM,
+                yearString,
+                CHANNEL_REGISTRY_PAGE_COUNT_PARAM,
+                String.valueOf(size),
+                CHANNEL_REGISTRY_PAGE_NO_PARAM,
+                String.valueOf(offset / size),
+                NAME_QUERY_PARAM,
+                name);
+        var input =
+                constructRequest(
+                        Map.of(
+                                "year",
+                                yearString,
+                                "query",
+                                name,
+                                "offset",
+                                String.valueOf(offset),
+                                "size",
+                                String.valueOf(size)),
+                        MediaType.ANY_TYPE);
+
+        handlerUnderTest.handleRequest(input, output, context);
+
+        var response = GatewayResponse.fromOutputStream(output, PaginatedSearchResult.class);
+        var pagesSearchResult = objectMapper.readValue(response.getBody(), TYPE_REF);
+
+        var expectedSearchResult =
+                getExpectedPaginatedSearchPublisherResultNameSearch(
+                        result, yearString, name, offset, size);
+        var expectedUri = expectedSearchResult.getId();
+        var actualUri = pagesSearchResult.getId();
+
+        assertTrue(areEqualURIs(actualUri, expectedUri));
     }
 
     @ParameterizedTest(name = "year {0} is invalid")

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/publisher/SearchPublisherByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/publisher/SearchPublisherByQueryHandlerTest.java
@@ -35,7 +35,6 @@ import static nva.commons.core.attempt.Try.attempt;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.samePropertyValuesAs;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.StringContains.containsString;
@@ -132,7 +131,6 @@ class SearchPublisherByQueryHandlerTest {
         var contentType = response.getHeaders().get(CONTENT_TYPE);
         assertThat(contentType, is(equalTo(expectedMediaType)));
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
-        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test
@@ -151,7 +149,6 @@ class SearchPublisherByQueryHandlerTest {
 
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
-        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test
@@ -171,7 +168,6 @@ class SearchPublisherByQueryHandlerTest {
 
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
-        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test
@@ -203,7 +199,6 @@ class SearchPublisherByQueryHandlerTest {
         var expectedSearchResult = getExpectedPaginatedSearchPublisherResultNameSearch(
             result, yearString, name, offset, size);
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
-        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test
@@ -237,7 +232,6 @@ class SearchPublisherByQueryHandlerTest {
                                                                                        offset,
                                                                                        size);
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
-        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test
@@ -271,7 +265,6 @@ class SearchPublisherByQueryHandlerTest {
         var expectedSearchResult = getExpectedPaginatedSearchPublisherResultNameSearch(
             result, yearString, name, offset, size);
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
-        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/series/SearchSeriesByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/series/SearchSeriesByQueryHandlerTest.java
@@ -34,7 +34,6 @@ import static nva.commons.core.attempt.Try.attempt;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.samePropertyValuesAs;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.StringContains.containsString;
@@ -155,7 +154,6 @@ class SearchSeriesByQueryHandlerTest {
         var contentType = response.getHeaders().get(CONTENT_TYPE);
         assertThat(contentType, is(equalTo(expectedMediaType)));
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
-        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test
@@ -173,7 +171,6 @@ class SearchSeriesByQueryHandlerTest {
 
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
-        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test
@@ -192,7 +189,6 @@ class SearchSeriesByQueryHandlerTest {
 
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
-        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test
@@ -223,7 +219,6 @@ class SearchSeriesByQueryHandlerTest {
         var expectedSearchResult = getExpectedPaginatedSearchResultNameSearch(
             result, yearString, name, offset, size);
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
-        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test
@@ -254,7 +249,6 @@ class SearchSeriesByQueryHandlerTest {
         assertThat(pagesSearchResult.getTotalHits(), is(equalTo(result.size())));
         var expectedSearchResult = getExpectedPaginatedSearchResultNameSearch(result, null, name, offset, size);
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
-        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test
@@ -288,7 +282,6 @@ class SearchSeriesByQueryHandlerTest {
         var expectedSearchResult = getExpectedPaginatedSearchResultNameSearch(result, yearString, name,
                                                                               offset, size);
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
-        assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
     }
 
     @Test

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/series/SearchSeriesByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/series/SearchSeriesByQueryHandlerTest.java
@@ -3,6 +3,7 @@ package no.sikt.nva.pubchannels.handler.search.series;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+
 import static no.sikt.nva.pubchannels.HttpHeaders.ACCEPT;
 import static no.sikt.nva.pubchannels.HttpHeaders.CONTENT_TYPE;
 import static no.sikt.nva.pubchannels.TestCommons.CHANNEL_REGISTRY_PAGE_COUNT_PARAM;
@@ -14,6 +15,7 @@ import static no.sikt.nva.pubchannels.TestCommons.DEFAULT_SIZE_INT;
 import static no.sikt.nva.pubchannels.TestCommons.ISSN_QUERY_PARAM;
 import static no.sikt.nva.pubchannels.TestCommons.NAME_QUERY_PARAM;
 import static no.sikt.nva.pubchannels.TestCommons.YEAR_QUERY_PARAM;
+import static no.sikt.nva.pubchannels.handler.TestUtils.areEqualURIs;
 import static no.sikt.nva.pubchannels.handler.TestUtils.constructPublicationChannelUri;
 import static no.sikt.nva.pubchannels.handler.TestUtils.createChannelRegistryJournalResponse;
 import static no.sikt.nva.pubchannels.handler.TestUtils.createSeries;
@@ -27,14 +29,18 @@ import static no.unit.nva.testutils.RandomDataGenerator.objectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.randomIssn;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
+
 import static nva.commons.core.attempt.Try.attempt;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.samePropertyValuesAs;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
+
 import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -43,6 +49,28 @@ import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.github.tomakehurst.wiremock.matching.StringValuePattern;
 import com.google.common.net.MediaType;
+
+import no.sikt.nva.pubchannels.channelregistry.ChannelRegistryClient;
+import no.sikt.nva.pubchannels.channelregistry.model.ChannelRegistrySeries;
+import no.sikt.nva.pubchannels.handler.ThirdPartySeries;
+import no.sikt.nva.pubchannels.handler.model.SeriesDto;
+import no.unit.nva.commons.pagination.PaginatedSearchResult;
+import no.unit.nva.stubs.FakeContext;
+import no.unit.nva.stubs.WiremockHttpClient;
+import no.unit.nva.testutils.HandlerRequestBuilder;
+
+import nva.commons.apigateway.GatewayResponse;
+import nva.commons.apigateway.exceptions.UnprocessableContentException;
+import nva.commons.core.Environment;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+import org.zalando.problem.Problem;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -55,24 +83,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import no.sikt.nva.pubchannels.channelregistry.ChannelRegistryClient;
-import no.sikt.nva.pubchannels.channelregistry.model.ChannelRegistrySeries;
-import no.sikt.nva.pubchannels.handler.ThirdPartySeries;
-import no.sikt.nva.pubchannels.handler.model.SeriesDto;
-import no.unit.nva.commons.pagination.PaginatedSearchResult;
-import no.unit.nva.stubs.FakeContext;
-import no.unit.nva.stubs.WiremockHttpClient;
-import no.unit.nva.testutils.HandlerRequestBuilder;
-import nva.commons.apigateway.GatewayResponse;
-import nva.commons.apigateway.exceptions.UnprocessableContentException;
-import nva.commons.core.Environment;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mockito;
-import org.zalando.problem.Problem;
 
 @WireMockTest(httpsEnabled = true)
 class SearchSeriesByQueryHandlerTest {
@@ -279,6 +289,53 @@ class SearchSeriesByQueryHandlerTest {
                                                                               offset, size);
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
         assertThat(pagesSearchResult, samePropertyValuesAs(expectedSearchResult));
+    }
+
+    @Test
+    void shouldReturnResultWithQueryAsId() throws IOException, UnprocessableContentException {
+        var year = randomYear();
+        var yearString = String.valueOf(year);
+        var name = randomString();
+        int offset = 10;
+        int size = 10;
+        int maxNr = 30;
+        var result = getChannelRegistrySearchResult(year, name, maxNr);
+        stubChannelRegistrySearchResponse(
+                getChannelRegistryResponseBody(result, offset, size),
+                HttpURLConnection.HTTP_OK,
+                YEAR_QUERY_PARAM,
+                yearString,
+                CHANNEL_REGISTRY_PAGE_COUNT_PARAM,
+                String.valueOf(size),
+                CHANNEL_REGISTRY_PAGE_NO_PARAM,
+                String.valueOf(offset / size),
+                NAME_QUERY_PARAM,
+                name);
+        var input =
+                constructRequest(
+                        Map.of(
+                                "year",
+                                yearString,
+                                "query",
+                                name,
+                                "offset",
+                                String.valueOf(offset),
+                                "size",
+                                String.valueOf(size)),
+                        MediaType.ANY_TYPE);
+
+        handlerUnderTest.handleRequest(input, output, context);
+
+        var response = GatewayResponse.fromOutputStream(output, PaginatedSearchResult.class);
+        var pagesSearchResult = objectMapper.readValue(response.getBody(), TYPE_REF);
+
+        var expectedSearchResult =
+                getExpectedPaginatedSearchResultNameSearch(result, yearString, name, offset, size);
+
+        var expectedUri = expectedSearchResult.getId();
+        var actualUri = pagesSearchResult.getId();
+
+        assertTrue(areEqualURIs(actualUri, expectedUri));
     }
 
     @ParameterizedTest(name = "year {0} is invalid")


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-47567

Fixes flaky tests by removing a `samePropertyValuesAs` assertion from various unit tests that was intended to check that responses contained a query URL matching the actual query.
This was flaky because the assertion compared string values and order of query parameters was random in some cases, meaning a test like this would fail:

```
@Test
void example() throws URISyntaxException {
    URI uri1 = new URI("http://www.example.com?foo=1&bar=2");
    URI uri2 = new URI("http://www.example.com?bar=2&foo=1");
    assertThat(uri1, is(equalTo(uri2)));
}
```


This PR replaces these assertions with a dedicated test case and a custom equality check.
