### PR TITLE
Remove misleading logging

### DIFF
--- a/src/main/java/no/sikt/nva/pubchannels/channelregistry/ChannelRegistryClient.java
+++ b/src/main/java/no/sikt/nva/pubchannels/channelregistry/ChannelRegistryClient.java
@@ -130,12 +130,12 @@ public class ChannelRegistryClient implements PublicationChannelClient {
     }
 
     private ApiGatewayException logAndCreateBadGatewayException(URI uri, Exception e) {
-        LOGGER.error("Unable to reach upstream: {}", uri, e);
         if (e instanceof InterruptedException) {
             Thread.currentThread().interrupt();
         } else if (e instanceof ApiGatewayException) {
             return (ApiGatewayException) e;
         }
+        LOGGER.error("Unable to reach upstream: {}", uri, e);
         return new BadGatewayException("Unable to reach upstream!");
     }
 

--- a/src/main/java/no/sikt/nva/pubchannels/channelregistry/ChannelRegistryClient.java
+++ b/src/main/java/no/sikt/nva/pubchannels/channelregistry/ChannelRegistryClient.java
@@ -132,6 +132,7 @@ public class ChannelRegistryClient implements PublicationChannelClient {
 
     private ApiGatewayException logAndCreateBadGatewayException(URI uri, Exception e) {
         if (e instanceof InterruptedException) {
+            LOGGER.error("Thread interrupted when fetching: {}", uri, e);
             Thread.currentThread().interrupt();
         } else if (e instanceof ApiGatewayException) {
             return (ApiGatewayException) e;

--- a/src/main/java/no/sikt/nva/pubchannels/channelregistry/ChannelRegistryClient.java
+++ b/src/main/java/no/sikt/nva/pubchannels/channelregistry/ChannelRegistryClient.java
@@ -106,15 +106,16 @@ public class ChannelRegistryClient implements PublicationChannelClient {
         var response = httpClient.send(request, BodyHandlers.ofString());
 
         if (!OK_STATUSES.contains(response.statusCode())) {
-            handleError(response);
+            handleError(request.uri(), response);
         }
 
         return attempt(() -> dtoObjectMapper.readValue(response.body(), clazz)).orElseThrow();
     }
 
-    private void handleError(HttpResponse<String> response) throws ApiGatewayException {
+    private void handleError(URI requestedUri, HttpResponse<String> response) throws ApiGatewayException {
         var statusCode = response.statusCode();
         if (HTTP_NOT_FOUND == statusCode) {
+            LOGGER.error("Publication channel not found: {} {}", requestedUri, response.body());
             throw new NotFoundException("Publication channel not found!");
         }
         if (HTTP_BAD_REQUEST == statusCode) {
@@ -122,10 +123,10 @@ public class ChannelRegistryClient implements PublicationChannelClient {
         }
         if (HTTP_MOVED_PERM == statusCode) {
             var location = response.headers().map().get("Location").getFirst();
-            LOGGER.info("Publication channel moved permanently to: {}", location);
+            LOGGER.info("Publication channel {} moved permanently to: {}", requestedUri, location);
             throw new PublicationChannelMovedException("Publication channel moved permanently!", URI.create(location));
         }
-        LOGGER.error("Error fetching publication channel: {} {}", statusCode, response.body());
+        LOGGER.error("Error fetching publication channel: {} {} {}", requestedUri, statusCode, response.body());
         throw new BadGatewayException("Unexpected response from upstream!");
     }
 

--- a/src/test/java/no/sikt/nva/pubchannels/handler/fetch/journal/FetchJournalByIdentifierAndYearHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/fetch/journal/FetchJournalByIdentifierAndYearHandlerTest.java
@@ -272,7 +272,8 @@ class FetchJournalByIdentifierAndYearHandlerTest {
         var appender = LogUtils.getTestingAppenderForRootLogger();
         handlerUnderTest.handleRequest(input, output, context);
 
-        assertThat(appender.getMessages(), containsString("Error fetching publication channel: 500"));
+        assertThat(appender.getMessages(), containsString("Error fetching publication channel"));
+        assertThat(appender.getMessages(), containsString("500"));
 
         var response = GatewayResponse.fromOutputStream(output, Problem.class);
 

--- a/src/test/java/no/sikt/nva/pubchannels/handler/fetch/publisher/FetchPublisherByIdentifierAndYearHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/fetch/publisher/FetchPublisherByIdentifierAndYearHandlerTest.java
@@ -234,7 +234,8 @@ class FetchPublisherByIdentifierAndYearHandlerTest {
         var appender = LogUtils.getTestingAppenderForRootLogger();
         handlerUnderTest.handleRequest(input, output, context);
 
-        assertThat(appender.getMessages(), containsString("Error fetching publication channel: 500"));
+        assertThat(appender.getMessages(), containsString("Error fetching publication channel"));
+        assertThat(appender.getMessages(), containsString("500"));
 
         var response = GatewayResponse.fromOutputStream(output, Problem.class);
 

--- a/src/test/java/no/sikt/nva/pubchannels/handler/fetch/series/FetchSeriesByIdentifierAndYearHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/fetch/series/FetchSeriesByIdentifierAndYearHandlerTest.java
@@ -230,7 +230,8 @@ class FetchSeriesByIdentifierAndYearHandlerTest {
         var appender = LogUtils.getTestingAppenderForRootLogger();
         handlerUnderTest.handleRequest(input, output, context);
 
-        assertThat(appender.getMessages(), containsString("Error fetching publication channel: 500"));
+        assertThat(appender.getMessages(), containsString("Error fetching publication channel"));
+        assertThat(appender.getMessages(), containsString("500"));
 
         var response = GatewayResponse.fromOutputStream(output, Problem.class);
 


### PR DESCRIPTION
Changes:
- Do not log "Unable to reach upstream" if known `ApiGatewayException`
- Log `requestedUri` on `404`-response, `301`-response or unexpected response code