### PR TITLE
Taking in use cache for fetch endpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,5 +8,5 @@ dependencies {
 test {
     environment("ALLOWED_ORIGIN", "*")
     environment("CHANNEL_REGISTER_CACHE_BUCKET", "someBucket")
-    environment("CHANNEL_REGISTER_CACHE", "someFile")
+    environment("CHANNEL_REGISTER_CACHE_S3_OBJECT", "someFile")
 }

--- a/src/main/java/no/sikt/nva/pubchannels/channelregistrycache/CachedPublicationChannelNotFoundException.java
+++ b/src/main/java/no/sikt/nva/pubchannels/channelregistrycache/CachedPublicationChannelNotFoundException.java
@@ -1,6 +1,8 @@
 package no.sikt.nva.pubchannels.channelregistrycache;
 
-public class CachedPublicationChannelNotFoundException extends RuntimeException {
+import nva.commons.apigateway.exceptions.NotFoundException;
+
+public class CachedPublicationChannelNotFoundException extends NotFoundException {
 
     public CachedPublicationChannelNotFoundException(String message) {
         super(message);

--- a/src/main/java/no/sikt/nva/pubchannels/channelregistrycache/ChannelRegistryCacheConfig.java
+++ b/src/main/java/no/sikt/nva/pubchannels/channelregistrycache/ChannelRegistryCacheConfig.java
@@ -1,0 +1,12 @@
+package no.sikt.nva.pubchannels.channelregistrycache;
+
+import nva.commons.core.Environment;
+
+public final class ChannelRegistryCacheConfig {
+
+    public static final String CACHE_BUCKET = new Environment().readEnv("CHANNEL_REGISTER_CACHE_BUCKET");
+    public static final String CHANNEL_REGISTER_CACHE_S3_OBJECT = new Environment().readEnv(
+        "CHANNEL_REGISTER_CACHE_S3_OBJECT");
+    private ChannelRegistryCacheConfig() {
+    }
+}

--- a/src/main/java/no/sikt/nva/pubchannels/channelregistrycache/ChannelRegistryCacheConfig.java
+++ b/src/main/java/no/sikt/nva/pubchannels/channelregistrycache/ChannelRegistryCacheConfig.java
@@ -4,9 +4,11 @@ import nva.commons.core.Environment;
 
 public final class ChannelRegistryCacheConfig {
 
-    public static final String CACHE_BUCKET = new Environment().readEnv("CHANNEL_REGISTER_CACHE_BUCKET");
-    public static final String CHANNEL_REGISTER_CACHE_S3_OBJECT = new Environment().readEnv(
+    public static final Environment ENVIRONMENT = new Environment();
+    public static final String CACHE_BUCKET = ENVIRONMENT.readEnv("CHANNEL_REGISTER_CACHE_BUCKET");
+    public static final String CHANNEL_REGISTER_CACHE_S3_OBJECT = ENVIRONMENT.readEnv(
         "CHANNEL_REGISTER_CACHE_S3_OBJECT");
+
     private ChannelRegistryCacheConfig() {
     }
 }

--- a/src/main/java/no/sikt/nva/pubchannels/channelregistrycache/ChannelRegistryCsvCacheClient.java
+++ b/src/main/java/no/sikt/nva/pubchannels/channelregistrycache/ChannelRegistryCsvCacheClient.java
@@ -7,12 +7,15 @@ import java.util.List;
 import no.sikt.nva.pubchannels.channelregistry.ChannelType;
 import no.sikt.nva.pubchannels.handler.PublicationChannelFetchClient;
 import no.sikt.nva.pubchannels.handler.ThirdPartyPublicationChannel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 
 public final class ChannelRegistryCsvCacheClient implements PublicationChannelFetchClient {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(ChannelRegistryCsvCacheClient.class);
     public static final String CHANNEL_NOT_FOUND_MESSAGE = "Could not find cached publication channel with id %s and type %s";
     private final List<ChannelRegistryCacheEntry> cacheEntries;
 
@@ -43,6 +46,7 @@ public final class ChannelRegistryCsvCacheClient implements PublicationChannelFe
     }
 
     private CachedPublicationChannelNotFoundException throwException(String identifier, ChannelType type) {
+        LOGGER.error("Could not find cached publication channel with id {} and type {}", identifier, type);
         return new CachedPublicationChannelNotFoundException(CHANNEL_NOT_FOUND_MESSAGE.formatted(identifier, type.name()));
     }
 

--- a/src/main/java/no/sikt/nva/pubchannels/handler/fetch/FetchByIdentifierAndYearHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/fetch/FetchByIdentifierAndYearHandler.java
@@ -13,9 +13,7 @@ import java.net.URI;
 import java.time.Year;
 import java.util.List;
 import no.sikt.nva.pubchannels.channelregistry.ChannelRegistryClient;
-import no.sikt.nva.pubchannels.channelregistrycache.ChannelRegistryCsvCacheClient;
 import no.sikt.nva.pubchannels.handler.PublicationChannelClient;
-import no.sikt.nva.pubchannels.handler.PublicationChannelFetchClient;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
@@ -33,22 +31,22 @@ public abstract class FetchByIdentifierAndYearHandler<I, O> extends ApiGatewayHa
     private static final String IDENTIFIER_PATH_PARAM_NAME = "identifier";
 
     protected final PublicationChannelClient publicationChannelClient;
-    protected final PublicationChannelFetchClient cacheClient;
+    protected final S3Client s3Client;
     protected final boolean shouldUseCache;
 
     @JacocoGenerated
     protected FetchByIdentifierAndYearHandler(Class<I> iclass, Environment environment) {
         super(iclass, environment);
         this.publicationChannelClient = ChannelRegistryClient.defaultInstance();
-        this.cacheClient = ChannelRegistryCsvCacheClient.load(S3Client.create());
+        this.s3Client = S3Client.create();
         this.shouldUseCache = Boolean.parseBoolean(environment.readEnv("SHOULD_USE_CACHE"));
     }
 
     protected FetchByIdentifierAndYearHandler(Class<I> requestClass, Environment environment,
-                                              PublicationChannelClient client, PublicationChannelFetchClient cacheClient) {
+                                              PublicationChannelClient client, S3Client s3Client) {
         super(requestClass, environment);
         this.publicationChannelClient = client;
-        this.cacheClient = cacheClient;
+        this.s3Client = s3Client;
         this.shouldUseCache = Boolean.parseBoolean(environment.readEnv("SHOULD_USE_CACHE"));
     }
 

--- a/src/main/java/no/sikt/nva/pubchannels/handler/fetch/journal/FetchJournalByIdentifierAndYearHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/fetch/journal/FetchJournalByIdentifierAndYearHandler.java
@@ -2,6 +2,7 @@ package no.sikt.nva.pubchannels.handler.fetch.journal;
 
 import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
+import java.net.HttpURLConnection;
 import java.util.function.Function;
 import no.sikt.nva.pubchannels.channelregistry.ChannelType;
 import no.sikt.nva.pubchannels.channelregistry.PublicationChannelMovedException;
@@ -60,7 +61,7 @@ public class FetchJournalByIdentifierAndYearHandler extends FetchByIdentifierAnd
     private ThirdPartyPublicationChannel fetchFromCacheWhenServerError(FetchByIdAndYearRequest request,
                                                                        ApiGatewayException e)
         throws ApiGatewayException {
-        if (e.getStatusCode() >= 500) {
+        if (e.getStatusCode() >= HttpURLConnection.HTTP_INTERNAL_ERROR) {
             return attempt(() -> fetchJournalFromCache(request)).orElseThrow(throwOriginalException(e));
         } else {
             throw e;

--- a/src/main/java/no/sikt/nva/pubchannels/handler/fetch/journal/FetchJournalByIdentifierAndYearHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/fetch/journal/FetchJournalByIdentifierAndYearHandler.java
@@ -82,6 +82,7 @@ public class FetchJournalByIdentifierAndYearHandler extends FetchByIdentifierAnd
     private ThirdPartyPublicationChannel fetchJournal(FetchByIdAndYearRequest request, String requestYear)
         throws ApiGatewayException {
         try {
+            LOGGER.info("Fetching journal from channel register: {}", request.getIdentifier());
             return publicationChannelClient.getChannel(ChannelType.JOURNAL, request.getIdentifier(), requestYear);
         } catch (PublicationChannelMovedException movedException) {
             throw new PublicationChannelMovedException("Journal moved",

--- a/src/main/java/no/sikt/nva/pubchannels/handler/fetch/journal/FetchJournalByIdentifierAndYearHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/fetch/journal/FetchJournalByIdentifierAndYearHandler.java
@@ -5,8 +5,8 @@ import com.amazonaws.services.lambda.runtime.Context;
 import java.util.function.Function;
 import no.sikt.nva.pubchannels.channelregistry.ChannelType;
 import no.sikt.nva.pubchannels.channelregistry.PublicationChannelMovedException;
+import no.sikt.nva.pubchannels.channelregistrycache.ChannelRegistryCsvCacheClient;
 import no.sikt.nva.pubchannels.handler.PublicationChannelClient;
-import no.sikt.nva.pubchannels.handler.PublicationChannelFetchClient;
 import no.sikt.nva.pubchannels.handler.ThirdPartyJournal;
 import no.sikt.nva.pubchannels.handler.ThirdPartyPublicationChannel;
 import no.sikt.nva.pubchannels.handler.fetch.FetchByIdentifierAndYearHandler;
@@ -18,6 +18,7 @@ import nva.commons.core.JacocoGenerated;
 import nva.commons.core.attempt.Failure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.s3.S3Client;
 
 public class FetchJournalByIdentifierAndYearHandler extends FetchByIdentifierAndYearHandler<Void, JournalDto> {
 
@@ -31,8 +32,8 @@ public class FetchJournalByIdentifierAndYearHandler extends FetchByIdentifierAnd
 
     public FetchJournalByIdentifierAndYearHandler(Environment environment,
                                                   PublicationChannelClient publicationChannelClient,
-                                                  PublicationChannelFetchClient cacheClient) {
-        super(Void.class, environment, publicationChannelClient, cacheClient);
+                                                  S3Client s3Client) {
+        super(Void.class, environment, publicationChannelClient, s3Client);
     }
 
     @Override
@@ -74,7 +75,8 @@ public class FetchJournalByIdentifierAndYearHandler extends FetchByIdentifierAnd
     private ThirdPartyPublicationChannel fetchJournalFromCache(FetchByIdAndYearRequest request)
         throws ApiGatewayException {
         LOGGER.info("Fetching journal from cache: {}", request.getIdentifier());
-        return cacheClient.getChannel(ChannelType.JOURNAL, request.getIdentifier(), request.getYear());
+        return ChannelRegistryCsvCacheClient.load(s3Client)
+                   .getChannel(ChannelType.JOURNAL, request.getIdentifier(), request.getYear());
     }
 
     private ThirdPartyPublicationChannel fetchJournal(FetchByIdAndYearRequest request, String requestYear)

--- a/src/main/java/no/sikt/nva/pubchannels/handler/fetch/journal/FetchJournalByIdentifierAndYearHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/fetch/journal/FetchJournalByIdentifierAndYearHandler.java
@@ -1,9 +1,12 @@
 package no.sikt.nva.pubchannels.handler.fetch.journal;
 
+import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
+import java.util.function.Function;
 import no.sikt.nva.pubchannels.channelregistry.ChannelType;
 import no.sikt.nva.pubchannels.channelregistry.PublicationChannelMovedException;
 import no.sikt.nva.pubchannels.handler.PublicationChannelClient;
+import no.sikt.nva.pubchannels.handler.PublicationChannelFetchClient;
 import no.sikt.nva.pubchannels.handler.ThirdPartyJournal;
 import no.sikt.nva.pubchannels.handler.ThirdPartyPublicationChannel;
 import no.sikt.nva.pubchannels.handler.fetch.FetchByIdentifierAndYearHandler;
@@ -12,9 +15,13 @@ import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
+import nva.commons.core.attempt.Failure;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class FetchJournalByIdentifierAndYearHandler extends FetchByIdentifierAndYearHandler<Void, JournalDto> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(FetchJournalByIdentifierAndYearHandler.class);
     private static final String JOURNAL_PATH_ELEMENT = "journal";
 
     @JacocoGenerated
@@ -23,8 +30,9 @@ public class FetchJournalByIdentifierAndYearHandler extends FetchByIdentifierAnd
     }
 
     public FetchJournalByIdentifierAndYearHandler(Environment environment,
-                                                  PublicationChannelClient publicationChannelClient) {
-        super(Void.class, environment, publicationChannelClient);
+                                                  PublicationChannelClient publicationChannelClient,
+                                                  PublicationChannelFetchClient cacheClient) {
+        super(Void.class, environment, publicationChannelClient, cacheClient);
     }
 
     @Override
@@ -34,8 +42,39 @@ public class FetchJournalByIdentifierAndYearHandler extends FetchByIdentifierAnd
         var journalIdBaseUri = constructPublicationChannelIdBaseUri(JOURNAL_PATH_ELEMENT);
 
         var requestYear = request.getYear();
-        var journal = fetchJournal(request, requestYear);
+
+        var journal = shouldUseCache ? fetchJournalFromCache(request) : fetchJournalOrFetchFromCache(request);
         return JournalDto.create(journalIdBaseUri, (ThirdPartyJournal) journal, requestYear);
+    }
+
+    private ThirdPartyPublicationChannel fetchJournalOrFetchFromCache(FetchByIdAndYearRequest request)
+        throws ApiGatewayException {
+        try {
+            return fetchJournal(request, request.getYear());
+        } catch (ApiGatewayException e) {
+            return fetchFromCacheWhenServerError(request, e);
+        }
+    }
+
+    private ThirdPartyPublicationChannel fetchFromCacheWhenServerError(FetchByIdAndYearRequest request,
+                                                                       ApiGatewayException e)
+        throws ApiGatewayException {
+        if (e.getStatusCode() >= 500) {
+            return attempt(() -> fetchJournalFromCache(request)).orElseThrow(throwOriginalException(e));
+        } else {
+            throw e;
+        }
+    }
+
+    private static Function<Failure<ThirdPartyPublicationChannel>, ApiGatewayException> throwOriginalException(
+        ApiGatewayException e) {
+        return failure -> e;
+    }
+
+    private ThirdPartyPublicationChannel fetchJournalFromCache(FetchByIdAndYearRequest request)
+        throws ApiGatewayException {
+        LOGGER.info("Fetching journal from cache: {}", request.getIdentifier());
+        return cacheClient.getChannel(ChannelType.JOURNAL, request.getIdentifier(), request.getYear());
     }
 
     private ThirdPartyPublicationChannel fetchJournal(FetchByIdAndYearRequest request, String requestYear)

--- a/src/main/java/no/sikt/nva/pubchannels/handler/fetch/publisher/FetchPublisherByIdentifierAndYearHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/fetch/publisher/FetchPublisherByIdentifierAndYearHandler.java
@@ -3,6 +3,7 @@ package no.sikt.nva.pubchannels.handler.fetch.publisher;
 import static no.sikt.nva.pubchannels.channelregistry.ChannelType.PUBLISHER;
 import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
+import java.net.HttpURLConnection;
 import java.util.function.Function;
 import no.sikt.nva.pubchannels.channelregistry.PublicationChannelMovedException;
 import no.sikt.nva.pubchannels.channelregistrycache.ChannelRegistryCsvCacheClient;
@@ -68,7 +69,7 @@ public class FetchPublisherByIdentifierAndYearHandler extends
     private ThirdPartyPublicationChannel fetchFromCacheWhenServerError(FetchByIdAndYearRequest request,
         ApiGatewayException e)
         throws ApiGatewayException {
-        if (e.getStatusCode() >= 500) {
+        if (e.getStatusCode() >= HttpURLConnection.HTTP_INTERNAL_ERROR) {
             return attempt(() -> fetchPublisherFromCache(request)).orElseThrow(throwOriginalException(e));
         } else {
             throw e;

--- a/src/main/java/no/sikt/nva/pubchannels/handler/fetch/publisher/FetchPublisherByIdentifierAndYearHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/fetch/publisher/FetchPublisherByIdentifierAndYearHandler.java
@@ -1,9 +1,12 @@
 package no.sikt.nva.pubchannels.handler.fetch.publisher;
 
 import static no.sikt.nva.pubchannels.channelregistry.ChannelType.PUBLISHER;
+import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
+import java.util.function.Function;
 import no.sikt.nva.pubchannels.channelregistry.PublicationChannelMovedException;
 import no.sikt.nva.pubchannels.handler.PublicationChannelClient;
+import no.sikt.nva.pubchannels.handler.PublicationChannelFetchClient;
 import no.sikt.nva.pubchannels.handler.ThirdPartyPublicationChannel;
 import no.sikt.nva.pubchannels.handler.ThirdPartyPublisher;
 import no.sikt.nva.pubchannels.handler.fetch.FetchByIdentifierAndYearHandler;
@@ -12,10 +15,14 @@ import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
+import nva.commons.core.attempt.Failure;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class FetchPublisherByIdentifierAndYearHandler extends
                                                       FetchByIdentifierAndYearHandler<Void, PublisherDto> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(FetchPublisherByIdentifierAndYearHandler.class);
     private static final String PUBLISHER_PATH_ELEMENT = "publisher";
 
     @JacocoGenerated
@@ -24,8 +31,9 @@ public class FetchPublisherByIdentifierAndYearHandler extends
     }
 
     public FetchPublisherByIdentifierAndYearHandler(Environment environment,
-                                                    PublicationChannelClient publicationChannelClient) {
-        super(Void.class, environment, publicationChannelClient);
+                                                    PublicationChannelClient publicationChannelClient,
+                                                    PublicationChannelFetchClient cacheClient) {
+        super(Void.class, environment, publicationChannelClient, cacheClient);
     }
 
     @Override
@@ -36,9 +44,39 @@ public class FetchPublisherByIdentifierAndYearHandler extends
         var publisherIdBaseUri = constructPublicationChannelIdBaseUri(PUBLISHER_PATH_ELEMENT);
 
         var requestYear = request.getYear();
-        var publisher = fetchPublisher(request, requestYear);
+        var publisher = shouldUseCache ? fetchPublisherFromCache(request) : fetchPublisherOrFetchFromCache(request);
         return PublisherDto.create(publisherIdBaseUri,
                                    (ThirdPartyPublisher) publisher, requestYear);
+    }
+
+    private ThirdPartyPublicationChannel fetchPublisherFromCache(FetchByIdAndYearRequest request)
+        throws ApiGatewayException {
+        LOGGER.info("Fetching publisher from cache: {}", request.getIdentifier());
+        return cacheClient.getChannel(PUBLISHER, request.getIdentifier(), request.getYear());
+    }
+
+    private ThirdPartyPublicationChannel fetchPublisherOrFetchFromCache(FetchByIdAndYearRequest request)
+        throws ApiGatewayException {
+        try {
+            return fetchPublisher(request, request.getYear());
+        } catch (ApiGatewayException e) {
+            return fetchFromCacheWhenServerError(request, e);
+        }
+    }
+
+    private ThirdPartyPublicationChannel fetchFromCacheWhenServerError(FetchByIdAndYearRequest request,
+        ApiGatewayException e)
+        throws ApiGatewayException {
+        if (e.getStatusCode() >= 500) {
+            return attempt(() -> fetchPublisherFromCache(request)).orElseThrow(throwOriginalException(e));
+        } else {
+            throw e;
+        }
+    }
+
+    private static Function<Failure<ThirdPartyPublicationChannel>, ApiGatewayException> throwOriginalException(
+        ApiGatewayException e) {
+        return failure -> e;
     }
 
     private ThirdPartyPublicationChannel fetchPublisher(FetchByIdAndYearRequest request, String requestYear)

--- a/src/main/java/no/sikt/nva/pubchannels/handler/fetch/publisher/FetchPublisherByIdentifierAndYearHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/fetch/publisher/FetchPublisherByIdentifierAndYearHandler.java
@@ -5,8 +5,8 @@ import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import java.util.function.Function;
 import no.sikt.nva.pubchannels.channelregistry.PublicationChannelMovedException;
+import no.sikt.nva.pubchannels.channelregistrycache.ChannelRegistryCsvCacheClient;
 import no.sikt.nva.pubchannels.handler.PublicationChannelClient;
-import no.sikt.nva.pubchannels.handler.PublicationChannelFetchClient;
 import no.sikt.nva.pubchannels.handler.ThirdPartyPublicationChannel;
 import no.sikt.nva.pubchannels.handler.ThirdPartyPublisher;
 import no.sikt.nva.pubchannels.handler.fetch.FetchByIdentifierAndYearHandler;
@@ -18,6 +18,7 @@ import nva.commons.core.JacocoGenerated;
 import nva.commons.core.attempt.Failure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.s3.S3Client;
 
 public class FetchPublisherByIdentifierAndYearHandler extends
                                                       FetchByIdentifierAndYearHandler<Void, PublisherDto> {
@@ -32,8 +33,8 @@ public class FetchPublisherByIdentifierAndYearHandler extends
 
     public FetchPublisherByIdentifierAndYearHandler(Environment environment,
                                                     PublicationChannelClient publicationChannelClient,
-                                                    PublicationChannelFetchClient cacheClient) {
-        super(Void.class, environment, publicationChannelClient, cacheClient);
+                                                    S3Client s3Client) {
+        super(Void.class, environment, publicationChannelClient, s3Client);
     }
 
     @Override
@@ -52,7 +53,7 @@ public class FetchPublisherByIdentifierAndYearHandler extends
     private ThirdPartyPublicationChannel fetchPublisherFromCache(FetchByIdAndYearRequest request)
         throws ApiGatewayException {
         LOGGER.info("Fetching publisher from cache: {}", request.getIdentifier());
-        return cacheClient.getChannel(PUBLISHER, request.getIdentifier(), request.getYear());
+        return ChannelRegistryCsvCacheClient.load(s3Client).getChannel(PUBLISHER, request.getIdentifier(), request.getYear());
     }
 
     private ThirdPartyPublicationChannel fetchPublisherOrFetchFromCache(FetchByIdAndYearRequest request)

--- a/src/main/java/no/sikt/nva/pubchannels/handler/fetch/publisher/FetchPublisherByIdentifierAndYearHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/fetch/publisher/FetchPublisherByIdentifierAndYearHandler.java
@@ -83,6 +83,7 @@ public class FetchPublisherByIdentifierAndYearHandler extends
     private ThirdPartyPublicationChannel fetchPublisher(FetchByIdAndYearRequest request, String requestYear)
         throws ApiGatewayException {
         try {
+            LOGGER.info("Fetching publisher from channel register: {}", request.getIdentifier());
             return publicationChannelClient.getChannel(PUBLISHER, request.getIdentifier(), requestYear);
         } catch (PublicationChannelMovedException movedException) {
             throw new PublicationChannelMovedException(

--- a/src/main/java/no/sikt/nva/pubchannels/handler/fetch/series/FetchSeriesByIdentifierAndYearHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/fetch/series/FetchSeriesByIdentifierAndYearHandler.java
@@ -79,6 +79,7 @@ public class FetchSeriesByIdentifierAndYearHandler extends FetchByIdentifierAndY
     private ThirdPartyPublicationChannel fetchSeries(FetchByIdAndYearRequest request, String requestYear)
         throws ApiGatewayException {
         try {
+            LOGGER.info("Fetching series from channel register: {}", request.getIdentifier());
             return publicationChannelClient.getChannel(SERIES, request.getIdentifier(), requestYear);
         } catch (PublicationChannelMovedException movedException) {
             throw new PublicationChannelMovedException("Series moved", constructNewLocation(SERIES_PATH_ELEMENT,

--- a/src/main/java/no/sikt/nva/pubchannels/handler/fetch/series/FetchSeriesByIdentifierAndYearHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/fetch/series/FetchSeriesByIdentifierAndYearHandler.java
@@ -1,9 +1,12 @@
 package no.sikt.nva.pubchannels.handler.fetch.series;
 
 import static no.sikt.nva.pubchannels.channelregistry.ChannelType.SERIES;
+import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
+import java.util.function.Function;
 import no.sikt.nva.pubchannels.channelregistry.PublicationChannelMovedException;
 import no.sikt.nva.pubchannels.handler.PublicationChannelClient;
+import no.sikt.nva.pubchannels.handler.PublicationChannelFetchClient;
 import no.sikt.nva.pubchannels.handler.ThirdPartyPublicationChannel;
 import no.sikt.nva.pubchannels.handler.ThirdPartySeries;
 import no.sikt.nva.pubchannels.handler.fetch.FetchByIdentifierAndYearHandler;
@@ -12,9 +15,13 @@ import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
+import nva.commons.core.attempt.Failure;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class FetchSeriesByIdentifierAndYearHandler extends FetchByIdentifierAndYearHandler<Void, SeriesDto> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(FetchSeriesByIdentifierAndYearHandler.class);
     private static final String SERIES_PATH_ELEMENT = "series";
 
     @JacocoGenerated
@@ -23,8 +30,9 @@ public class FetchSeriesByIdentifierAndYearHandler extends FetchByIdentifierAndY
     }
 
     public FetchSeriesByIdentifierAndYearHandler(Environment environment,
-                                                 PublicationChannelClient publicationChannelClient) {
-        super(Void.class, environment, publicationChannelClient);
+                                                 PublicationChannelClient publicationChannelClient,
+                                                 PublicationChannelFetchClient cacheClient) {
+        super(Void.class, environment, publicationChannelClient, cacheClient);
     }
 
     @Override
@@ -33,8 +41,38 @@ public class FetchSeriesByIdentifierAndYearHandler extends FetchByIdentifierAndY
         var publisherIdBaseUri = constructPublicationChannelIdBaseUri(SERIES_PATH_ELEMENT);
 
         var requestYear = request.getYear();
-        var series = fetchSeries(request, requestYear);
+        var series = shouldUseCache ? fetchSeriesFromCache(request) : fetchSeriesOrFetchFromCache(request);
         return SeriesDto.create(publisherIdBaseUri, (ThirdPartySeries) series, requestYear);
+    }
+
+    private static Function<Failure<ThirdPartyPublicationChannel>, ApiGatewayException> throwOriginalException(
+        ApiGatewayException e) {
+        return failure -> e;
+    }
+
+    private ThirdPartyPublicationChannel fetchSeriesOrFetchFromCache(FetchByIdAndYearRequest request)
+        throws ApiGatewayException {
+        try {
+            return fetchSeries(request, request.getYear());
+        } catch (ApiGatewayException e) {
+            return fetchFromCacheWhenServerError(request, e);
+        }
+    }
+
+    private ThirdPartyPublicationChannel fetchFromCacheWhenServerError(FetchByIdAndYearRequest request,
+                                                                       ApiGatewayException e)
+        throws ApiGatewayException {
+        if (e.getStatusCode() >= 500) {
+            return attempt(() -> fetchSeriesFromCache(request)).orElseThrow(throwOriginalException(e));
+        } else {
+            throw e;
+        }
+    }
+
+    private ThirdPartyPublicationChannel fetchSeriesFromCache(FetchByIdAndYearRequest request)
+        throws ApiGatewayException {
+        LOGGER.info("Fetching series from cache: {}", request.getIdentifier());
+        return cacheClient.getChannel(SERIES, request.getIdentifier(), request.getYear());
     }
 
     private ThirdPartyPublicationChannel fetchSeries(FetchByIdAndYearRequest request, String requestYear)
@@ -42,10 +80,9 @@ public class FetchSeriesByIdentifierAndYearHandler extends FetchByIdentifierAndY
         try {
             return publicationChannelClient.getChannel(SERIES, request.getIdentifier(), requestYear);
         } catch (PublicationChannelMovedException movedException) {
-            throw new PublicationChannelMovedException("Series moved",
-                                                       constructNewLocation(SERIES_PATH_ELEMENT,
-                                                                            movedException.getLocation(),
-                                                                            requestYear));
+            throw new PublicationChannelMovedException("Series moved", constructNewLocation(SERIES_PATH_ELEMENT,
+                                                                                            movedException.getLocation(),
+                                                                                            requestYear));
         }
     }
 }

--- a/src/main/java/no/sikt/nva/pubchannels/handler/fetch/series/FetchSeriesByIdentifierAndYearHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/fetch/series/FetchSeriesByIdentifierAndYearHandler.java
@@ -5,8 +5,8 @@ import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import java.util.function.Function;
 import no.sikt.nva.pubchannels.channelregistry.PublicationChannelMovedException;
+import no.sikt.nva.pubchannels.channelregistrycache.ChannelRegistryCsvCacheClient;
 import no.sikt.nva.pubchannels.handler.PublicationChannelClient;
-import no.sikt.nva.pubchannels.handler.PublicationChannelFetchClient;
 import no.sikt.nva.pubchannels.handler.ThirdPartyPublicationChannel;
 import no.sikt.nva.pubchannels.handler.ThirdPartySeries;
 import no.sikt.nva.pubchannels.handler.fetch.FetchByIdentifierAndYearHandler;
@@ -18,6 +18,7 @@ import nva.commons.core.JacocoGenerated;
 import nva.commons.core.attempt.Failure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.s3.S3Client;
 
 public class FetchSeriesByIdentifierAndYearHandler extends FetchByIdentifierAndYearHandler<Void, SeriesDto> {
 
@@ -31,8 +32,8 @@ public class FetchSeriesByIdentifierAndYearHandler extends FetchByIdentifierAndY
 
     public FetchSeriesByIdentifierAndYearHandler(Environment environment,
                                                  PublicationChannelClient publicationChannelClient,
-                                                 PublicationChannelFetchClient cacheClient) {
-        super(Void.class, environment, publicationChannelClient, cacheClient);
+                                                 S3Client s3Client) {
+        super(Void.class, environment, publicationChannelClient, s3Client);
     }
 
     @Override
@@ -72,7 +73,7 @@ public class FetchSeriesByIdentifierAndYearHandler extends FetchByIdentifierAndY
     private ThirdPartyPublicationChannel fetchSeriesFromCache(FetchByIdAndYearRequest request)
         throws ApiGatewayException {
         LOGGER.info("Fetching series from cache: {}", request.getIdentifier());
-        return cacheClient.getChannel(SERIES, request.getIdentifier(), request.getYear());
+        return ChannelRegistryCsvCacheClient.load(s3Client).getChannel(SERIES, request.getIdentifier(), request.getYear());
     }
 
     private ThirdPartyPublicationChannel fetchSeries(FetchByIdAndYearRequest request, String requestYear)

--- a/src/main/java/no/sikt/nva/pubchannels/handler/fetch/series/FetchSeriesByIdentifierAndYearHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/fetch/series/FetchSeriesByIdentifierAndYearHandler.java
@@ -3,6 +3,7 @@ package no.sikt.nva.pubchannels.handler.fetch.series;
 import static no.sikt.nva.pubchannels.channelregistry.ChannelType.SERIES;
 import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
+import java.net.HttpURLConnection;
 import java.util.function.Function;
 import no.sikt.nva.pubchannels.channelregistry.PublicationChannelMovedException;
 import no.sikt.nva.pubchannels.channelregistrycache.ChannelRegistryCsvCacheClient;
@@ -63,7 +64,7 @@ public class FetchSeriesByIdentifierAndYearHandler extends FetchByIdentifierAndY
     private ThirdPartyPublicationChannel fetchFromCacheWhenServerError(FetchByIdAndYearRequest request,
                                                                        ApiGatewayException e)
         throws ApiGatewayException {
-        if (e.getStatusCode() >= 500) {
+        if (e.getStatusCode() >= HttpURLConnection.HTTP_INTERNAL_ERROR) {
             return attempt(() -> fetchSeriesFromCache(request)).orElseThrow(throwOriginalException(e));
         } else {
             throw e;

--- a/src/test/java/no/sikt/nva/pubchannels/channelregistrycache/ChannelRegistryCsvCacheClientTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/channelregistrycache/ChannelRegistryCsvCacheClientTest.java
@@ -3,34 +3,24 @@ package no.sikt.nva.pubchannels.channelregistrycache;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import java.io.IOException;
 import java.net.URI;
-import java.nio.file.Path;
 import no.sikt.nva.pubchannels.channelregistry.ChannelType;
 import no.sikt.nva.pubchannels.channelregistry.model.ChannelRegistryJournal;
 import no.sikt.nva.pubchannels.channelregistry.model.ChannelRegistryLevel;
 import no.sikt.nva.pubchannels.channelregistry.model.ChannelRegistryPublisher;
 import no.sikt.nva.pubchannels.channelregistry.model.ChannelRegistrySeries;
-import no.unit.nva.s3.S3Driver;
-import no.unit.nva.stubs.FakeS3Client;
-import nva.commons.core.ioutils.IoUtils;
-import nva.commons.core.paths.UnixPath;
+import no.sikt.nva.pubchannels.handler.fetch.ChannelRegistryCacheSetup;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.services.s3.S3Client;
 
-class ChannelRegistryCsvCacheClientTest {
-
-    public static final String BUCKET_NAME = "someBucket";
-    public static final String FILE_NAME = "someFile";
+class ChannelRegistryCsvCacheClientTest extends ChannelRegistryCacheSetup {
 
     private ChannelRegistryCsvCacheClient cacheClient;
 
     @BeforeEach
-    void setUp() throws IOException {
-        var s3Client = new FakeS3Client();
-        initiateS3BucketWithCacheFile(s3Client);
-        this.cacheClient = ChannelRegistryCsvCacheClient.load(s3Client);
+    void setUp() {
+        super.setup();
+        cacheClient = super.getCacheClient();
     }
 
     @Test
@@ -41,11 +31,11 @@ class ChannelRegistryCsvCacheClientTest {
         assertThrows(CachedPublicationChannelNotFoundException.class,
                      () -> cacheClient.getChannel(ChannelType.JOURNAL, channelIdentifier, year),
                      "Could not find cached publication channel with id %s and type %s".formatted(channelIdentifier,
-                                                                                                    "JOURNAL"));
+                                                                                                  "JOURNAL"));
     }
 
     @Test
-    void shouldLoadCachedPublicationChannelWhenJournal() {
+    void shouldLoadCachedPublicationChannelWhenJournal() throws CachedPublicationChannelNotFoundException {
         var channelIdentifier = "50561B90-6679-4FCD-BCB0-99E521B18962";
         var year = "2008";
 
@@ -56,7 +46,7 @@ class ChannelRegistryCsvCacheClientTest {
     }
 
     @Test
-    void shouldLoadCachedPublicationChannelWhenSeries() {
+    void shouldLoadCachedPublicationChannelWhenSeries() throws CachedPublicationChannelNotFoundException {
         var channelIdentifier = "50561B90-6679-4FCD-BCB0-99E521B18962";
         var year = "2008";
 
@@ -67,7 +57,7 @@ class ChannelRegistryCsvCacheClientTest {
     }
 
     @Test
-    void shouldLoadCachedPublicationChannelWhenPublisher() {
+    void shouldLoadCachedPublicationChannelWhenPublisher() throws CachedPublicationChannelNotFoundException {
         var channelIdentifier = "09D6F92E-B0F6-4B62-90AB-1B9E767E9E11";
         var year = "2024";
 
@@ -101,10 +91,5 @@ class ChannelRegistryCsvCacheClientTest {
         return new ChannelRegistryPublisher(channelIdentifier,
                                             new ChannelRegistryLevel(Integer.parseInt(year), null, null, null, null),
                                             "978-1-9996187", "Agenda Publishing", URI.create(homepage), null);
-    }
-
-    private void initiateS3BucketWithCacheFile(S3Client s3Client) throws IOException {
-        var csv = IoUtils.stringFromResources(Path.of("cache.csv"));
-        new S3Driver(s3Client, BUCKET_NAME).insertFile(UnixPath.of(FILE_NAME), csv);
     }
 }

--- a/src/test/java/no/sikt/nva/pubchannels/channelregistrycache/ChannelRegistryCsvCacheClientTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/channelregistrycache/ChannelRegistryCsvCacheClientTest.java
@@ -20,7 +20,7 @@ class ChannelRegistryCsvCacheClientTest extends ChannelRegistryCacheSetup {
     @BeforeEach
     void setUp() {
         super.setup();
-        cacheClient = super.getCacheClient();
+        cacheClient = ChannelRegistryCsvCacheClient.load(super.getS3Client());
     }
 
     @Test

--- a/src/test/java/no/sikt/nva/pubchannels/handler/fetch/ChannelRegistryCacheSetup.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/fetch/ChannelRegistryCacheSetup.java
@@ -3,7 +3,6 @@ package no.sikt.nva.pubchannels.handler.fetch;
 import static nva.commons.core.attempt.Try.attempt;
 import java.nio.file.Path;
 import no.sikt.nva.pubchannels.channelregistrycache.ChannelRegistryCacheConfig;
-import no.sikt.nva.pubchannels.channelregistrycache.ChannelRegistryCsvCacheClient;
 import no.unit.nva.s3.S3Driver;
 import no.unit.nva.stubs.FakeS3Client;
 import nva.commons.core.ioutils.IoUtils;
@@ -11,19 +10,18 @@ import nva.commons.core.paths.UnixPath;
 
 public class ChannelRegistryCacheSetup {
 
-    private ChannelRegistryCsvCacheClient cacheClient;
+    private FakeS3Client s3Client;
 
-    public ChannelRegistryCsvCacheClient getCacheClient() {
-        return cacheClient;
+    public FakeS3Client getS3Client() {
+        return s3Client;
     }
 
     public void setup() {
         var csv = IoUtils.stringFromResources(Path.of("cache.csv"));
-        var s3Client = new FakeS3Client();
+        s3Client = new FakeS3Client();
         var s3Driver = new S3Driver(s3Client, ChannelRegistryCacheConfig.CACHE_BUCKET);
         attempt(() -> s3Driver.insertFile(UnixPath.of(ChannelRegistryCacheConfig.CHANNEL_REGISTER_CACHE_S3_OBJECT),
                                           csv)).orElseThrow();
-        this.cacheClient = ChannelRegistryCsvCacheClient.load(s3Client);
     }
 
     public String getCachedJournalSeriesIdentifier() {

--- a/src/test/java/no/sikt/nva/pubchannels/handler/fetch/ChannelRegistryCacheSetup.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/fetch/ChannelRegistryCacheSetup.java
@@ -1,0 +1,40 @@
+package no.sikt.nva.pubchannels.handler.fetch;
+
+import static nva.commons.core.attempt.Try.attempt;
+import java.nio.file.Path;
+import no.sikt.nva.pubchannels.channelregistrycache.ChannelRegistryCacheConfig;
+import no.sikt.nva.pubchannels.channelregistrycache.ChannelRegistryCsvCacheClient;
+import no.unit.nva.s3.S3Driver;
+import no.unit.nva.stubs.FakeS3Client;
+import nva.commons.core.ioutils.IoUtils;
+import nva.commons.core.paths.UnixPath;
+
+public class ChannelRegistryCacheSetup {
+
+    private ChannelRegistryCsvCacheClient cacheClient;
+
+    public ChannelRegistryCsvCacheClient getCacheClient() {
+        return cacheClient;
+    }
+
+    public void setup() {
+        var csv = IoUtils.stringFromResources(Path.of("cache.csv"));
+        var s3Client = new FakeS3Client();
+        var s3Driver = new S3Driver(s3Client, ChannelRegistryCacheConfig.CACHE_BUCKET);
+        attempt(() -> s3Driver.insertFile(UnixPath.of(ChannelRegistryCacheConfig.CHANNEL_REGISTER_CACHE_S3_OBJECT),
+                                          csv)).orElseThrow();
+        this.cacheClient = ChannelRegistryCsvCacheClient.load(s3Client);
+    }
+
+    public String getCachedJournalSeriesIdentifier() {
+        return "50561B90-6679-4FCD-BCB0-99E521B18962";
+    }
+
+    public String getCachedJournalSeriesYear() {
+        return "2024";
+    }
+
+    public String getCachedPublisherIdentifier() {
+        return "09D6F92E-B0F6-4B62-90AB-1B9E767E9E11";
+    }
+}

--- a/src/test/java/no/sikt/nva/pubchannels/handler/fetch/journal/FetchJournalByIdentifierAndYearHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/fetch/journal/FetchJournalByIdentifierAndYearHandlerTest.java
@@ -81,7 +81,7 @@ class FetchJournalByIdentifierAndYearHandlerTest extends ChannelRegistryCacheSet
         channelRegistryBaseUri = runtimeInfo.getHttpsBaseUrl();
         var httpClient = WiremockHttpClient.create();
         var publicationChannelSource = new ChannelRegistryClient(httpClient, URI.create(channelRegistryBaseUri), null);
-        this.handlerUnderTest = new FetchJournalByIdentifierAndYearHandler(environment, publicationChannelSource, super.getCacheClient());
+        this.handlerUnderTest = new FetchJournalByIdentifierAndYearHandler(environment, publicationChannelSource, super.getS3Client());
         this.mockRegistry = new PublicationChannelMockClient();
         this.output = new ByteArrayOutputStream();
     }
@@ -240,7 +240,7 @@ class FetchJournalByIdentifierAndYearHandlerTest extends ChannelRegistryCacheSet
         var httpClient = WiremockHttpClient.create();
         var channelRegistryBaseUri = URI.create("https://localhost:9898");
         var publicationChannelSource = new ChannelRegistryClient(httpClient, channelRegistryBaseUri, null);
-        this.handlerUnderTest = new FetchJournalByIdentifierAndYearHandler(environment, publicationChannelSource, super.getCacheClient());
+        this.handlerUnderTest = new FetchJournalByIdentifierAndYearHandler(environment, publicationChannelSource, super.getS3Client());
 
         var identifier = UUID.randomUUID().toString();
         var year = randomYear();
@@ -270,7 +270,7 @@ class FetchJournalByIdentifierAndYearHandlerTest extends ChannelRegistryCacheSet
         var channelRegistryBaseUri = URI.create("https://localhost:9898");
         var publicationChannelSource = new ChannelRegistryClient(httpClient, channelRegistryBaseUri, null);
 
-        this.handlerUnderTest = new FetchJournalByIdentifierAndYearHandler(environment, publicationChannelSource, super.getCacheClient());
+        this.handlerUnderTest = new FetchJournalByIdentifierAndYearHandler(environment, publicationChannelSource, super.getS3Client());
 
         var input = constructRequest(randomYear(), UUID.randomUUID().toString());
 
@@ -354,7 +354,7 @@ class FetchJournalByIdentifierAndYearHandlerTest extends ChannelRegistryCacheSet
         var httpClient = WiremockHttpClient.create();
         var channelRegistryBaseUri = URI.create("https://localhost:9898");
         var publicationChannelSource = new ChannelRegistryClient(httpClient, channelRegistryBaseUri, null);
-        this.handlerUnderTest = new FetchJournalByIdentifierAndYearHandler(environment, publicationChannelSource, super.getCacheClient());
+        this.handlerUnderTest = new FetchJournalByIdentifierAndYearHandler(environment, publicationChannelSource, super.getS3Client());
 
         var identifier = super.getCachedJournalSeriesIdentifier();
         var year = super.getCachedJournalSeriesYear();
@@ -378,7 +378,7 @@ class FetchJournalByIdentifierAndYearHandlerTest extends ChannelRegistryCacheSet
         var channelRegistryBaseUri = URI.create("https://localhost:9898");
         var publicationChannelSource = new ChannelRegistryClient(httpClient, channelRegistryBaseUri, null);
         when(environment.readEnv("SHOULD_USE_CACHE")).thenReturn("true");
-        this.handlerUnderTest = new FetchJournalByIdentifierAndYearHandler(environment, publicationChannelSource, super.getCacheClient());
+        this.handlerUnderTest = new FetchJournalByIdentifierAndYearHandler(environment, publicationChannelSource, super.getS3Client());
 
         var identifier = super.getCachedJournalSeriesIdentifier();
         var year = super.getCachedJournalSeriesYear();
@@ -402,7 +402,7 @@ class FetchJournalByIdentifierAndYearHandlerTest extends ChannelRegistryCacheSet
         var channelRegistryBaseUri = URI.create("https://localhost:9898");
         var publicationChannelSource = new ChannelRegistryClient(httpClient, channelRegistryBaseUri, null);
         when(environment.readEnv("SHOULD_USE_CACHE")).thenReturn("true");
-        this.handlerUnderTest = new FetchJournalByIdentifierAndYearHandler(environment, publicationChannelSource, super.getCacheClient());
+        this.handlerUnderTest = new FetchJournalByIdentifierAndYearHandler(environment, publicationChannelSource, super.getS3Client());
 
         var identifier = UUID.randomUUID().toString();
         var year = randomYear();

--- a/src/test/java/no/sikt/nva/pubchannels/handler/fetch/series/FetchSeriesByIdentifierAndYearHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/fetch/series/FetchSeriesByIdentifierAndYearHandlerTest.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.pubchannels.handler.fetch.series;
 
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static no.sikt.nva.pubchannels.HttpHeaders.CONTENT_TYPE;
 import static no.sikt.nva.pubchannels.TestCommons.ACCESS_CONTROL_ALLOW_ORIGIN;
@@ -38,6 +39,9 @@ import java.util.stream.Stream;
 import no.sikt.nva.pubchannels.channelregistry.ChannelRegistryClient;
 import no.sikt.nva.pubchannels.handler.TestChannel;
 import no.sikt.nva.pubchannels.handler.TestUtils;
+import no.sikt.nva.pubchannels.handler.fetch.ChannelRegistryCacheSetup;
+import no.sikt.nva.pubchannels.handler.fetch.journal.FetchJournalByIdentifierAndYearHandler;
+import no.sikt.nva.pubchannels.handler.model.JournalDto;
 import no.sikt.nva.pubchannels.handler.model.SeriesDto;
 import no.unit.nva.stubs.FakeContext;
 import no.unit.nva.stubs.WiremockHttpClient;
@@ -54,9 +58,10 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import org.zalando.problem.Problem;
+import software.amazon.awssdk.services.s3.endpoints.internal.Value.Int;
 
 @WireMockTest(httpsEnabled = true)
-class FetchSeriesByIdentifierAndYearHandlerTest {
+class FetchSeriesByIdentifierAndYearHandlerTest extends ChannelRegistryCacheSetup {
 
     private static final String SELF_URI_BASE = "https://localhost/publication-channels/" + SERIES_PATH;
     private static final String CHANNEL_REGISTRY_PATH_ELEMENT = "/findseries/";
@@ -68,15 +73,17 @@ class FetchSeriesByIdentifierAndYearHandlerTest {
 
     @BeforeEach
     void setup(WireMockRuntimeInfo runtimeInfo) {
+        super.setup();
         environment = Mockito.mock(Environment.class);
         when(environment.readEnv("ALLOWED_ORIGIN")).thenReturn(WILD_CARD);
         when(environment.readEnv("API_DOMAIN")).thenReturn(API_DOMAIN);
         when(environment.readEnv("CUSTOM_DOMAIN_BASE_PATH")).thenReturn(CUSTOM_DOMAIN_BASE_PATH);
+        when(environment.readEnv("SHOULD_USE_CACHE")).thenReturn("false");
 
         channelRegistryBaseUri = runtimeInfo.getHttpsBaseUrl();
         var httpClient = WiremockHttpClient.create();
         var publicationChannelClient = new ChannelRegistryClient(httpClient, URI.create(channelRegistryBaseUri), null);
-        this.handlerUnderTest = new FetchSeriesByIdentifierAndYearHandler(environment, publicationChannelClient);
+        this.handlerUnderTest = new FetchSeriesByIdentifierAndYearHandler(environment, publicationChannelClient, super.getCacheClient());
         this.output = new ByteArrayOutputStream();
     }
 
@@ -260,7 +267,7 @@ class FetchSeriesByIdentifierAndYearHandlerTest {
     }
 
     @Test
-    void shouldLogAndReturnBadGatewayWhenChannelClientReturnsUnhandledResponseCode() throws IOException {
+    void shouldLogAndReturnBadGatewayWhenChannelClientReturnsUnhandledResponseCodeAndSeriesIsNotCached() throws IOException {
         var identifier = UUID.randomUUID().toString();
         var year = String.valueOf(randomYear());
 
@@ -287,7 +294,8 @@ class FetchSeriesByIdentifierAndYearHandlerTest {
     void shouldLogErrorAndReturnBadGatewayWhenInterruptionOccurs() throws IOException, InterruptedException {
         ChannelRegistryClient publicationChannelClient = setupInterruptedClient();
 
-        this.handlerUnderTest = new FetchSeriesByIdentifierAndYearHandler(environment, publicationChannelClient);
+        this.handlerUnderTest = new FetchSeriesByIdentifierAndYearHandler(environment, publicationChannelClient,
+                                                                          super.getCacheClient());
 
         var input = constructRequest(String.valueOf(randomYear()), UUID.randomUUID().toString(), MediaType.ANY_TYPE);
 
@@ -322,6 +330,66 @@ class FetchSeriesByIdentifierAndYearHandlerTest {
         var expectedLocation = createPublicationChannelUri(newIdentifier, SERIES_PATH, year).toString();
         assertEquals(expectedLocation, response.getHeaders().get(LOCATION));
         assertEquals(WILD_CARD, response.getHeaders().get(ACCESS_CONTROL_ALLOW_ORIGIN));
+    }
+
+    @Test
+    void shouldReturnSeriesWhenChannelRegistryIsUnavailableAndSeriesIsCached() throws IOException {
+        var identifier = super.getCachedJournalSeriesIdentifier();
+        var year = super.getCachedJournalSeriesYear();
+
+        mockResponseWithHttpStatus("/findseries/", identifier, year, HttpURLConnection.HTTP_INTERNAL_ERROR);
+
+        var input = constructRequest(year, identifier, MediaType.ANY_TYPE);
+
+        var appender = LogUtils.getTestingAppenderForRootLogger();
+        handlerUnderTest.handleRequest(input, output, context);
+
+        assertThat(appender.getMessages(), containsString("Fetching series from cache: " + identifier));
+
+        var response = GatewayResponse.fromOutputStream(output, JournalDto.class);
+
+        assertThat(response.getStatusCode(), is(equalTo(HTTP_OK)));
+    }
+
+    @Test
+    void shouldReturnSeriesFromCacheWhenShouldUseCacheEnvironmentIsTrue() throws IOException {
+        var year = Integer.parseInt(super.getCachedJournalSeriesYear());
+        var identifier = super.getCachedJournalSeriesIdentifier();
+
+        var input = constructRequest(String.valueOf(year), identifier, MediaType.ANY_TYPE);
+
+        when(environment.readEnv("SHOULD_USE_CACHE")).thenReturn("true");
+        this.handlerUnderTest = new FetchSeriesByIdentifierAndYearHandler(environment, null, super.getCacheClient());
+        var appender = LogUtils.getTestingAppenderForRootLogger();
+
+        handlerUnderTest.handleRequest(input, output, context);
+
+        var response = GatewayResponse.fromOutputStream(output, SeriesDto.class);
+        assertThat(appender.getMessages(), containsString("Fetching series from cache: " + identifier));
+
+        var statusCode = response.getStatusCode();
+        assertThat(statusCode, is(equalTo(HttpURLConnection.HTTP_OK)));
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenShouldUseCacheEnvironmentVariableIsTrueButSeriesIsNotCached() throws IOException {
+        when(environment.readEnv("SHOULD_USE_CACHE")).thenReturn("true");
+        this.handlerUnderTest = new FetchSeriesByIdentifierAndYearHandler(environment, null, super.getCacheClient());
+
+        var identifier = UUID.randomUUID().toString();
+        var year = String.valueOf(randomYear());
+
+        var input = constructRequest(year, identifier, MediaType.ANY_TYPE);
+
+        var appender = LogUtils.getTestingAppenderForRootLogger();
+
+        handlerUnderTest.handleRequest(input, output, context);
+
+        assertThat(appender.getMessages(), containsString("Could not find cached publication channel with"));
+
+        var response = GatewayResponse.fromOutputStream(output, Problem.class);
+
+        assertThat(response.getStatusCode(), is(equalTo(HTTP_NOT_FOUND)));
     }
 
     private static Stream<String> invalidYearsProvider() {

--- a/template.yaml
+++ b/template.yaml
@@ -4,417 +4,417 @@ Description: >
   This template creates lambdas and apis for publication channels
 
 
-## More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
-#Globals:
-#  Function:
-#    Timeout: 40
-#    MemorySize: 1798
-#    Runtime: java21
-#    Architectures:
-#      - x86_64
-#    Environment:
-#      Variables:
-#        ALLOWED_ORIGIN: !Ref AllowedOrigins
-#        COGNITO_HOST: !Ref CognitoAuthorizationUri
-#        API_HOST: !Ref ApiDomain
-#        API_DOMAIN: !Ref ApiDomain
-#        CUSTOM_DOMAIN_BASE_PATH: !Ref CustomDomainBasePath
-#        DATAPORTEN_CHANNEL_REGISTRY_BASE_URL: !Ref DataportenChannelRegistryBaseUrl
-#
-#  Api:
-#    Cors:
-#      AllowOrigin: "'*'"
-#      AllowMethods: "'OPTIONS,GET'"
-#      AllowHeaders: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,Access-Control-Allow-Origin'"
-#
-#Parameters:
-#  ApiDomain:
-#    Type: AWS::SSM::Parameter::Value<String>
-#    Default: /NVA/ApiDomain
-#    Description: Domain-name for the backend
-#  DataportenChannelRegistryBaseUrl:
-#    Type: String
-#  CustomDomainBasePath:
-#    Type: String
-#    Description: Base path mapping in CustomDomain
-#    Default: publication-channels-v2
-#  CognitoAuthorizationUri:
-#    Type: 'AWS::SSM::Parameter::Value<String>'
-#    Default: '/NVA/CognitoUri'
-#  CognitoAuthorizerArn:
-#    Type: 'AWS::SSM::Parameter::Value<String>'
-#    Description: Reference to Cognito UserPool for the stage
-#    Default: CognitoAuthorizerArn
-#  AllowedOrigins:
-#    Type: String
-#    Description: comma separated list of external clients that are allowed to contact the HTTP APIs, "*" indicates that all origins are allowed
-#    Default: '*'
-#  SlackSnsArn:
-#    Type: AWS::SSM::Parameter::Value<String>
-#    Default: '/NVA/Monitoring/SlackSnsArn'
-#  ChannelRegisterCacheBucketName:
-#    Type: 'String'
-#    Default: "channel-register-cache"
-#    Description: Name of bucket for channel register cache csv
-#
+# More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
+Globals:
+  Function:
+    Timeout: 40
+    MemorySize: 1798
+    Runtime: java21
+    Architectures:
+      - x86_64
+    Environment:
+      Variables:
+        ALLOWED_ORIGIN: !Ref AllowedOrigins
+        COGNITO_HOST: !Ref CognitoAuthorizationUri
+        API_HOST: !Ref ApiDomain
+        API_DOMAIN: !Ref ApiDomain
+        CUSTOM_DOMAIN_BASE_PATH: !Ref CustomDomainBasePath
+        DATAPORTEN_CHANNEL_REGISTRY_BASE_URL: !Ref DataportenChannelRegistryBaseUrl
+
+  Api:
+    Cors:
+      AllowOrigin: "'*'"
+      AllowMethods: "'OPTIONS,GET'"
+      AllowHeaders: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,Access-Control-Allow-Origin'"
+
+Parameters:
+  ApiDomain:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /NVA/ApiDomain
+    Description: Domain-name for the backend
+  DataportenChannelRegistryBaseUrl:
+    Type: String
+  CustomDomainBasePath:
+    Type: String
+    Description: Base path mapping in CustomDomain
+    Default: publication-channels-v2
+  CognitoAuthorizationUri:
+    Type: 'AWS::SSM::Parameter::Value<String>'
+    Default: '/NVA/CognitoUri'
+  CognitoAuthorizerArn:
+    Type: 'AWS::SSM::Parameter::Value<String>'
+    Description: Reference to Cognito UserPool for the stage
+    Default: CognitoAuthorizerArn
+  AllowedOrigins:
+    Type: String
+    Description: comma separated list of external clients that are allowed to contact the HTTP APIs, "*" indicates that all origins are allowed
+    Default: '*'
+  SlackSnsArn:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: '/NVA/Monitoring/SlackSnsArn'
+  ChannelRegisterCacheBucketName:
+    Type: 'String'
+    Default: "channel-register-cache"
+    Description: Name of bucket for channel register cache csv
+
 Resources:
-#
+
   ApiAccessLogGroup:
     Type: AWS::Logs::LogGroup
-#
-#  PublicationChannelsApi:
-#    Type: AWS::Serverless::Api
-#    Properties:
-#      CacheClusterEnabled: true
-#      CacheClusterSize: "0.5"
-#      MethodSettings:
-#        - HttpMethod: 'GET'
-#          ResourcePath: '/~1journal~1{identifier}~1{year}'
-#          CacheTtlInSeconds: 3600
-#          CachingEnabled: true
-#        - HttpMethod: 'GET'
-#          ResourcePath: '/~1series~1{identifier}~1{year}'
-#          CacheTtlInSeconds: 3600
-#          CachingEnabled: true
-#        - HttpMethod: 'GET'
-#          ResourcePath: '/~1publisher~1{identifier}~1{year}'
-#          CacheTtlInSeconds: 3600
-#          CachingEnabled: true
-#        - HttpMethod: 'GET'
-#          ResourcePath: '/~1journal'
-#          CacheTtlInSeconds: 300
-#          CachingEnabled: false
-#        - HttpMethod: 'GET'
-#          ResourcePath: '/~1series'
-#          CacheTtlInSeconds: 300
-#          CachingEnabled: false
-#        - HttpMethod: 'GET'
-#          ResourcePath: '/~1publisher'
-#          CacheTtlInSeconds: 300
-#          CachingEnabled: false
-#      DefinitionBody:
-#        'Fn::Transform':
-#          Name: AWS::Include
-#          Parameters:
-#            Location: ./docs/openapi.yaml
-#      AccessLogSetting:
-#        DestinationArn: !GetAtt ApiAccessLogGroup.Arn
-#        Format: '{ "apiId": "$context.apiId", "requestId": "$context.requestId", "requestTime": "$context.requestTime", "requestTimeEpoch": "$context.requestTimeEpoch", "httpMethod": "$context.httpMethod", "path": "$context.path", "status": "$context.status",  "error.message": "$context.error.message" }'
-#      StageName: Prod
-#      Auth:
-#        DefaultAuthorizer: NONE
-#      EndpointConfiguration:
-#        Type: REGIONAL
-#
-#  LambdaRole:
-#    Type: AWS::IAM::Role
-#    Properties:
-#      AssumeRolePolicyDocument:
-#        Version: 2012-10-17
-#        Statement:
-#          - Effect: Allow
-#            Principal:
-#              Service: [ lambda.amazonaws.com ]
-#            Action: [ 'sts:AssumeRole' ]
-#      Policies:
-#        - PolicyName: writeLog
-#          PolicyDocument:
-#            Version: 2012-10-17
-#            Statement:
-#              - Effect: Allow
-#                Action:
-#                  - logs:CreateLogGroup
-#                  - logs:CreateLogStream
-#                  - logs:PutLogEvents
-#                Resource: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:*'
-#        - PolicyName: readSecrets
-#          PolicyDocument:
-#            Version: 2012-10-17
-#            Statement:
-#              - Effect: Allow
-#                Action:
-#                  - secretsmanager:GetSecretValue
-#                Resource: '*'
-#
-#  S3ManagedPolicy:
-#    Type: AWS::IAM::ManagedPolicy
-#    Properties:
-#      PolicyDocument:
-#        Version: '2012-10-17'
-#        Statement:
-#          - Effect: Allow
-#            Action:
-#              - s3:Get*
-#            Resource:
-#              - !Sub "arn:aws:s3:::${ChannelRegisterCacheBucketName}-${AWS::AccountId}/*"
-#
-#  FetchJournalByIdentifierAndYearFunction:
-#    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
-#    Properties:
-#      Handler: no.sikt.nva.pubchannels.handler.fetch.journal.FetchJournalByIdentifierAndYearHandler::handleRequest
-#      Role: !GetAtt LambdaRole.Arn
-#      Policies:
-#        - !Ref S3ManagedPolicy
-#      AutoPublishAlias: live
-#      #      SnapStart:
-#      #        ApplyOn: PublishedVersions
-#      Timeout: 60
-#      Events:
-#        FetchJournalByIdentifierAndYearEvent:
-#          Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
-#          Properties:
-#            RestApiId: !Ref PublicationChannelsApi
-#            Path: /journal/{identifier}/{year}
-#            Method: get
-#      Environment:
-#        Variables:
-#          CHANNEL_REGISTER_CACHE_BUCKET: !Ref ChannelRegisterCacheBucket
-#          CHANNEL_REGISTER_CACHE_S3_OBJECT: "cache.csv"
-#          SHOULD_USE_CACHE: "true"
-#
-#  FetchJournalByIdentifierAndYearFunctionPermission:
-#    Type: AWS::Lambda::Permission
-#    Properties:
-#      FunctionName: !GetAtt FetchJournalByIdentifierAndYearFunction.Arn
-#      Action: lambda:InvokeFunction
-#      Principal: 'apigateway.amazonaws.com'
-#
-#  FetchSeriesByIdentifierAndYearFunction:
-#    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
-#    Properties:
-#      Handler: no.sikt.nva.pubchannels.handler.fetch.series.FetchSeriesByIdentifierAndYearHandler::handleRequest
-#      Role: !GetAtt LambdaRole.Arn
-#      Policies:
-#        - !Ref S3ManagedPolicy
-#      AutoPublishAlias: live
-#      #      SnapStart:
-#      #        ApplyOn: PublishedVersions
-#      Timeout: 60
-#      Events:
-#        FetchSeriesByIdentifierAndYearEvent:
-#          Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
-#          Properties:
-#            RestApiId: !Ref PublicationChannelsApi
-#            Path: /series/{identifier}/{year}
-#            Method: get
-#      Environment:
-#        Variables:
-#          CHANNEL_REGISTER_CACHE_BUCKET: !Ref ChannelRegisterCacheBucket
-#          CHANNEL_REGISTER_CACHE_S3_OBJECT: "cache.csv"
-#          SHOULD_USE_CACHE: "true"
-#
-#  FetchSeriesByIdentifierAndYearFunctionPermission:
-#    Type: AWS::Lambda::Permission
-#    Properties:
-#      FunctionName: !GetAtt FetchSeriesByIdentifierAndYearFunction.Arn
-#      Action: lambda:InvokeFunction
-#      Principal: 'apigateway.amazonaws.com'
-#
-#  FetchPublisherByIdentifierAndYearFunction:
-#    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
-#    Properties:
-#      Handler: no.sikt.nva.pubchannels.handler.fetch.publisher.FetchPublisherByIdentifierAndYearHandler::handleRequest
-#      Role: !GetAtt LambdaRole.Arn
-#      Policies:
-#        - !Ref S3ManagedPolicy
-#      AutoPublishAlias: live
-#      #      SnapStart:
-#      #        ApplyOn: PublishedVersions
-#      Timeout: 60
-#      Events:
-#        FetchPublisherByIdentifierAndYearEvent:
-#          Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
-#          Properties:
-#            RestApiId: !Ref PublicationChannelsApi
-#            Path: /publisher/{identifier}/{year}
-#            Method: get
-#      Environment:
-#        Variables:
-#          CHANNEL_REGISTER_CACHE_BUCKET: !Ref ChannelRegisterCacheBucket
-#          CHANNEL_REGISTER_CACHE_S3_OBJECT: "cache.csv"
-#          SHOULD_USE_CACHE: "true"
-#
-#  FetchPublisherByIdentifierAndYearFunctionPermission:
-#    Type: AWS::Lambda::Permission
-#    Properties:
-#      FunctionName: !GetAtt FetchPublisherByIdentifierAndYearFunction.Arn
-#      Action: lambda:InvokeFunction
-#      Principal: 'apigateway.amazonaws.com'
-#
-#  SearchJournalByQueryFunction:
-#    Type: AWS::Serverless::Function
-#    Properties:
-#      Handler: no.sikt.nva.pubchannels.handler.search.journal.SearchJournalByQueryHandler::handleRequest
-#      Role: !GetAtt LambdaRole.Arn
-#      AutoPublishAlias: live
-#      Events:
-#        SearchJournalByQueryEvent:
-#          Type: Api
-#          Properties:
-#            RestApiId: !Ref PublicationChannelsApi
-#            Path: /journal
-#            Method: get
-#
-#  SearchJournalByQueryFunctionPermission:
-#    Type: AWS::Lambda::Permission
-#    Properties:
-#      FunctionName: !GetAtt SearchJournalByQueryFunction.Arn
-#      Action: lambda:InvokeFunction
-#      Principal: 'apigateway.amazonaws.com'
-#
-#  PublicationChannelsBasePathMapping:
-#    Type: AWS::ApiGateway::BasePathMapping
-#    Properties:
-#      BasePath: !Ref CustomDomainBasePath
-#      DomainName: !Ref ApiDomain
-#      RestApiId: !Ref PublicationChannelsApi
-#      Stage: !Ref PublicationChannelsApi.Stage
-#
-#  CreateJournalFunction:
-#    Type: AWS::Serverless::Function
-#    Properties:
-#      Handler: no.sikt.nva.pubchannels.handler.create.journal.CreateJournalHandler::handleRequest
-#      Role: !GetAtt LambdaRole.Arn
-#      AutoPublishAlias: live
-#      #      SnapStart:
-#      #        ApplyOn: PublishedVersions
-#      Events:
-#        CreateJournalEvent:
-#          Type: Api
-#          Properties:
-#            RestApiId: !Ref PublicationChannelsApi
-#            Path: /journal
-#            Method: post
-#
-#  CreateJournalFunctionPermission:
-#    Type: AWS::Lambda::Permission
-#    Properties:
-#      FunctionName: !GetAtt CreateJournalFunction.Arn
-#      Action: lambda:InvokeFunction
-#      Principal: 'apigateway.amazonaws.com'
-#
-#  SearchPublisherByQueryFunction:
-#    Type: AWS::Serverless::Function
-#    Properties:
-#      Handler: no.sikt.nva.pubchannels.handler.search.publisher.SearchPublisherByQueryHandler::handleRequest
-#      Role: !GetAtt LambdaRole.Arn
-#      AutoPublishAlias: live
-#      Events:
-#        SearchPublisherByQueryEvent:
-#          Type: Api
-#          Properties:
-#            RestApiId: !Ref PublicationChannelsApi
-#            Path: /publisher
-#            Method: get
-#
-#  SearchPublisherByQueryFunctionPermission:
-#    Type: AWS::Lambda::Permission
-#    Properties:
-#      FunctionName: !GetAtt SearchPublisherByQueryFunction.Arn
-#      Action: lambda:InvokeFunction
-#      Principal: 'apigateway.amazonaws.com'
-#
-#  CreatePublisherFunction:
-#    Type: AWS::Serverless::Function
-#    Properties:
-#      Handler: no.sikt.nva.pubchannels.handler.create.publisher.CreatePublisherHandler::handleRequest
-#      Role: !GetAtt LambdaRole.Arn
-#      AutoPublishAlias: live
-#      #      SnapStart:
-#      #        ApplyOn: PublishedVersions
-#      Events:
-#        CreatePublisherEvent:
-#          Type: Api
-#          Properties:
-#            RestApiId: !Ref PublicationChannelsApi
-#            Path: /publisher
-#            Method: post
-#
-#  CreatePublisherFunctionPermission:
-#    Type: AWS::Lambda::Permission
-#    Properties:
-#      FunctionName: !GetAtt CreatePublisherFunction.Arn
-#      Action: lambda:InvokeFunction
-#      Principal: 'apigateway.amazonaws.com'
-#
-#  SearchSeriesByQueryFunction:
-#    Type: AWS::Serverless::Function
-#    Properties:
-#      Handler: no.sikt.nva.pubchannels.handler.search.series.SearchSeriesByQueryHandler::handleRequest
-#      Role: !GetAtt LambdaRole.Arn
-#      AutoPublishAlias: live
-#      Events:
-#        SearchSeriesByQueryEvent:
-#          Type: Api
-#          Properties:
-#            RestApiId: !Ref PublicationChannelsApi
-#            Path: /series
-#            Method: get
-#
-#  SearchSeriesByQueryFunctionPermission:
-#    Type: AWS::Lambda::Permission
-#    Properties:
-#      FunctionName: !GetAtt SearchSeriesByQueryFunction.Arn
-#      Action: lambda:InvokeFunction
-#      Principal: 'apigateway.amazonaws.com'
-#
-#  CreateSeriesFunction:
-#    Type: AWS::Serverless::Function
-#    Properties:
-#      Handler: no.sikt.nva.pubchannels.handler.create.series.CreateSeriesHandler::handleRequest
-#      Role: !GetAtt LambdaRole.Arn
-#      AutoPublishAlias: live
-#      #      SnapStart:
-#      #        ApplyOn: PublishedVersions
-#      Events:
-#        CreateSeriesEvent:
-#          Type: Api
-#          Properties:
-#            RestApiId: !Ref PublicationChannelsApi
-#            Path: /series
-#            Method: post
-#
-#  CreateSeriesFunctionPermission:
-#    Type: AWS::Lambda::Permission
-#    Properties:
-#      FunctionName: !GetAtt CreateSeriesFunction.Arn
-#      Action: lambda:InvokeFunction
-#      Principal: 'apigateway.amazonaws.com'
-#
-#  DataportenChannelRegistryHealthCheck:
-#    Type: AWS::Route53::HealthCheck
-#    Properties:
-#      HealthCheckConfig:
-#        Port: 443
-#        Type: HTTPS
-#        ResourcePath: /health
-#        FullyQualifiedDomainName: !Select [2, !Split ["/", !Ref DataportenChannelRegistryBaseUrl]] # Extracts the domain name from the URL
-#        RequestInterval: 30
-#        FailureThreshold: 2
-#        EnableSNI: true
-#
-#  DataportenChannelRegistryHealthAlarm:
-#    Type: AWS::CloudWatch::Alarm
-#    Properties:
-#      AlarmName: !Sub External-Dataporten-Channel-Registry-API-HealthCheck-${PublicationChannelsApi} # PublicationChannelsApi is here just to make the name unique
-#      AlarmDescription: Check if external Dataporten Channel Registry API is healthy
-#      Namespace: AWS/Route53
-#      MetricName: HealthCheckStatus
-#      Dimensions:
-#        - Name: HealthCheckId
-#          Value: !GetAtt DataportenChannelRegistryHealthCheck.HealthCheckId
-#      Statistic: Minimum
-#      Period: 60
-#      EvaluationPeriods: 1
-#      DatapointsToAlarm: 1
-#      Threshold: 1
-#      ComparisonOperator: LessThanThreshold
-#      AlarmActions:
-#        - !Ref SlackSnsArn
-#      TreatMissingData: notBreaching
-#
-#  ChannelRegisterCacheBucket:
-#    Type: AWS::S3::Bucket
-#    Properties:
-#      BucketName: !Sub "${ChannelRegisterCacheBucketName}-${AWS::AccountId}"
-#
+
+  PublicationChannelsApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      CacheClusterEnabled: true
+      CacheClusterSize: "0.5"
+      MethodSettings:
+        - HttpMethod: 'GET'
+          ResourcePath: '/~1journal~1{identifier}~1{year}'
+          CacheTtlInSeconds: 3600
+          CachingEnabled: true
+        - HttpMethod: 'GET'
+          ResourcePath: '/~1series~1{identifier}~1{year}'
+          CacheTtlInSeconds: 3600
+          CachingEnabled: true
+        - HttpMethod: 'GET'
+          ResourcePath: '/~1publisher~1{identifier}~1{year}'
+          CacheTtlInSeconds: 3600
+          CachingEnabled: true
+        - HttpMethod: 'GET'
+          ResourcePath: '/~1journal'
+          CacheTtlInSeconds: 300
+          CachingEnabled: false
+        - HttpMethod: 'GET'
+          ResourcePath: '/~1series'
+          CacheTtlInSeconds: 300
+          CachingEnabled: false
+        - HttpMethod: 'GET'
+          ResourcePath: '/~1publisher'
+          CacheTtlInSeconds: 300
+          CachingEnabled: false
+      DefinitionBody:
+        'Fn::Transform':
+          Name: AWS::Include
+          Parameters:
+            Location: ./docs/openapi.yaml
+      AccessLogSetting:
+        DestinationArn: !GetAtt ApiAccessLogGroup.Arn
+        Format: '{ "apiId": "$context.apiId", "requestId": "$context.requestId", "requestTime": "$context.requestTime", "requestTimeEpoch": "$context.requestTimeEpoch", "httpMethod": "$context.httpMethod", "path": "$context.path", "status": "$context.status",  "error.message": "$context.error.message" }'
+      StageName: Prod
+      Auth:
+        DefaultAuthorizer: NONE
+      EndpointConfiguration:
+        Type: REGIONAL
+
+  LambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: [ lambda.amazonaws.com ]
+            Action: [ 'sts:AssumeRole' ]
+      Policies:
+        - PolicyName: writeLog
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:*'
+        - PolicyName: readSecrets
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                Resource: '*'
+
+  S3ManagedPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:Get*
+            Resource:
+              - !Sub "arn:aws:s3:::${ChannelRegisterCacheBucketName}-${AWS::AccountId}/*"
+
+  FetchJournalByIdentifierAndYearFunction:
+    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+    Properties:
+      Handler: no.sikt.nva.pubchannels.handler.fetch.journal.FetchJournalByIdentifierAndYearHandler::handleRequest
+      Role: !GetAtt LambdaRole.Arn
+      Policies:
+        - !Ref S3ManagedPolicy
+      AutoPublishAlias: live
+      #      SnapStart:
+      #        ApplyOn: PublishedVersions
+      Timeout: 60
+      Events:
+        FetchJournalByIdentifierAndYearEvent:
+          Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+          Properties:
+            RestApiId: !Ref PublicationChannelsApi
+            Path: /journal/{identifier}/{year}
+            Method: get
+      Environment:
+        Variables:
+          CHANNEL_REGISTER_CACHE_BUCKET: !Ref ChannelRegisterCacheBucket
+          CHANNEL_REGISTER_CACHE_S3_OBJECT: "cache.csv"
+          SHOULD_USE_CACHE: "true"
+
+  FetchJournalByIdentifierAndYearFunctionPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt FetchJournalByIdentifierAndYearFunction.Arn
+      Action: lambda:InvokeFunction
+      Principal: 'apigateway.amazonaws.com'
+
+  FetchSeriesByIdentifierAndYearFunction:
+    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+    Properties:
+      Handler: no.sikt.nva.pubchannels.handler.fetch.series.FetchSeriesByIdentifierAndYearHandler::handleRequest
+      Role: !GetAtt LambdaRole.Arn
+      Policies:
+        - !Ref S3ManagedPolicy
+      AutoPublishAlias: live
+      #      SnapStart:
+      #        ApplyOn: PublishedVersions
+      Timeout: 60
+      Events:
+        FetchSeriesByIdentifierAndYearEvent:
+          Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+          Properties:
+            RestApiId: !Ref PublicationChannelsApi
+            Path: /series/{identifier}/{year}
+            Method: get
+      Environment:
+        Variables:
+          CHANNEL_REGISTER_CACHE_BUCKET: !Ref ChannelRegisterCacheBucket
+          CHANNEL_REGISTER_CACHE_S3_OBJECT: "cache.csv"
+          SHOULD_USE_CACHE: "true"
+
+  FetchSeriesByIdentifierAndYearFunctionPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt FetchSeriesByIdentifierAndYearFunction.Arn
+      Action: lambda:InvokeFunction
+      Principal: 'apigateway.amazonaws.com'
+
+  FetchPublisherByIdentifierAndYearFunction:
+    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+    Properties:
+      Handler: no.sikt.nva.pubchannels.handler.fetch.publisher.FetchPublisherByIdentifierAndYearHandler::handleRequest
+      Role: !GetAtt LambdaRole.Arn
+      Policies:
+        - !Ref S3ManagedPolicy
+      AutoPublishAlias: live
+      #      SnapStart:
+      #        ApplyOn: PublishedVersions
+      Timeout: 60
+      Events:
+        FetchPublisherByIdentifierAndYearEvent:
+          Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+          Properties:
+            RestApiId: !Ref PublicationChannelsApi
+            Path: /publisher/{identifier}/{year}
+            Method: get
+      Environment:
+        Variables:
+          CHANNEL_REGISTER_CACHE_BUCKET: !Ref ChannelRegisterCacheBucket
+          CHANNEL_REGISTER_CACHE_S3_OBJECT: "cache.csv"
+          SHOULD_USE_CACHE: "true"
+
+  FetchPublisherByIdentifierAndYearFunctionPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt FetchPublisherByIdentifierAndYearFunction.Arn
+      Action: lambda:InvokeFunction
+      Principal: 'apigateway.amazonaws.com'
+
+  SearchJournalByQueryFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: no.sikt.nva.pubchannels.handler.search.journal.SearchJournalByQueryHandler::handleRequest
+      Role: !GetAtt LambdaRole.Arn
+      AutoPublishAlias: live
+      Events:
+        SearchJournalByQueryEvent:
+          Type: Api
+          Properties:
+            RestApiId: !Ref PublicationChannelsApi
+            Path: /journal
+            Method: get
+
+  SearchJournalByQueryFunctionPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt SearchJournalByQueryFunction.Arn
+      Action: lambda:InvokeFunction
+      Principal: 'apigateway.amazonaws.com'
+
+  PublicationChannelsBasePathMapping:
+    Type: AWS::ApiGateway::BasePathMapping
+    Properties:
+      BasePath: !Ref CustomDomainBasePath
+      DomainName: !Ref ApiDomain
+      RestApiId: !Ref PublicationChannelsApi
+      Stage: !Ref PublicationChannelsApi.Stage
+
+  CreateJournalFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: no.sikt.nva.pubchannels.handler.create.journal.CreateJournalHandler::handleRequest
+      Role: !GetAtt LambdaRole.Arn
+      AutoPublishAlias: live
+      #      SnapStart:
+      #        ApplyOn: PublishedVersions
+      Events:
+        CreateJournalEvent:
+          Type: Api
+          Properties:
+            RestApiId: !Ref PublicationChannelsApi
+            Path: /journal
+            Method: post
+
+  CreateJournalFunctionPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt CreateJournalFunction.Arn
+      Action: lambda:InvokeFunction
+      Principal: 'apigateway.amazonaws.com'
+
+  SearchPublisherByQueryFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: no.sikt.nva.pubchannels.handler.search.publisher.SearchPublisherByQueryHandler::handleRequest
+      Role: !GetAtt LambdaRole.Arn
+      AutoPublishAlias: live
+      Events:
+        SearchPublisherByQueryEvent:
+          Type: Api
+          Properties:
+            RestApiId: !Ref PublicationChannelsApi
+            Path: /publisher
+            Method: get
+
+  SearchPublisherByQueryFunctionPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt SearchPublisherByQueryFunction.Arn
+      Action: lambda:InvokeFunction
+      Principal: 'apigateway.amazonaws.com'
+
+  CreatePublisherFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: no.sikt.nva.pubchannels.handler.create.publisher.CreatePublisherHandler::handleRequest
+      Role: !GetAtt LambdaRole.Arn
+      AutoPublishAlias: live
+      #      SnapStart:
+      #        ApplyOn: PublishedVersions
+      Events:
+        CreatePublisherEvent:
+          Type: Api
+          Properties:
+            RestApiId: !Ref PublicationChannelsApi
+            Path: /publisher
+            Method: post
+
+  CreatePublisherFunctionPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt CreatePublisherFunction.Arn
+      Action: lambda:InvokeFunction
+      Principal: 'apigateway.amazonaws.com'
+
+  SearchSeriesByQueryFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: no.sikt.nva.pubchannels.handler.search.series.SearchSeriesByQueryHandler::handleRequest
+      Role: !GetAtt LambdaRole.Arn
+      AutoPublishAlias: live
+      Events:
+        SearchSeriesByQueryEvent:
+          Type: Api
+          Properties:
+            RestApiId: !Ref PublicationChannelsApi
+            Path: /series
+            Method: get
+
+  SearchSeriesByQueryFunctionPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt SearchSeriesByQueryFunction.Arn
+      Action: lambda:InvokeFunction
+      Principal: 'apigateway.amazonaws.com'
+
+  CreateSeriesFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: no.sikt.nva.pubchannels.handler.create.series.CreateSeriesHandler::handleRequest
+      Role: !GetAtt LambdaRole.Arn
+      AutoPublishAlias: live
+      #      SnapStart:
+      #        ApplyOn: PublishedVersions
+      Events:
+        CreateSeriesEvent:
+          Type: Api
+          Properties:
+            RestApiId: !Ref PublicationChannelsApi
+            Path: /series
+            Method: post
+
+  CreateSeriesFunctionPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt CreateSeriesFunction.Arn
+      Action: lambda:InvokeFunction
+      Principal: 'apigateway.amazonaws.com'
+
+  DataportenChannelRegistryHealthCheck:
+    Type: AWS::Route53::HealthCheck
+    Properties:
+      HealthCheckConfig:
+        Port: 443
+        Type: HTTPS
+        ResourcePath: /health
+        FullyQualifiedDomainName: !Select [2, !Split ["/", !Ref DataportenChannelRegistryBaseUrl]] # Extracts the domain name from the URL
+        RequestInterval: 30
+        FailureThreshold: 2
+        EnableSNI: true
+
+  DataportenChannelRegistryHealthAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub External-Dataporten-Channel-Registry-API-HealthCheck-${PublicationChannelsApi} # PublicationChannelsApi is here just to make the name unique
+      AlarmDescription: Check if external Dataporten Channel Registry API is healthy
+      Namespace: AWS/Route53
+      MetricName: HealthCheckStatus
+      Dimensions:
+        - Name: HealthCheckId
+          Value: !GetAtt DataportenChannelRegistryHealthCheck.HealthCheckId
+      Statistic: Minimum
+      Period: 60
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 1
+      ComparisonOperator: LessThanThreshold
+      AlarmActions:
+        - !Ref SlackSnsArn
+      TreatMissingData: notBreaching
+
+  ChannelRegisterCacheBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub "${ChannelRegisterCacheBucketName}-${AWS::AccountId}"
+

--- a/template.yaml
+++ b/template.yaml
@@ -145,8 +145,7 @@ Resources:
           - Effect: Allow
             Action:
               - s3:Get*
-            Resource:
-              !Ref ChannelRegisterCacheBucket
+            Resource: '*'
 
   FetchJournalByIdentifierAndYearFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction

--- a/template.yaml
+++ b/template.yaml
@@ -4,150 +4,150 @@ Description: >
   This template creates lambdas and apis for publication channels
 
 
-# More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
-Globals:
-  Function:
-    Timeout: 40
-    MemorySize: 1798
-    Runtime: java21
-    Architectures:
-      - x86_64
-    Environment:
-      Variables:
-        ALLOWED_ORIGIN: !Ref AllowedOrigins
-        COGNITO_HOST: !Ref CognitoAuthorizationUri
-        API_HOST: !Ref ApiDomain
-        API_DOMAIN: !Ref ApiDomain
-        CUSTOM_DOMAIN_BASE_PATH: !Ref CustomDomainBasePath
-        DATAPORTEN_CHANNEL_REGISTRY_BASE_URL: !Ref DataportenChannelRegistryBaseUrl
-
-  Api:
-    Cors:
-      AllowOrigin: "'*'"
-      AllowMethods: "'OPTIONS,GET'"
-      AllowHeaders: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,Access-Control-Allow-Origin'"
-
-Parameters:
-  ApiDomain:
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: /NVA/ApiDomain
-    Description: Domain-name for the backend
-  DataportenChannelRegistryBaseUrl:
-    Type: String
-  CustomDomainBasePath:
-    Type: String
-    Description: Base path mapping in CustomDomain
-    Default: publication-channels-v2
-  CognitoAuthorizationUri:
-    Type: 'AWS::SSM::Parameter::Value<String>'
-    Default: '/NVA/CognitoUri'
-  CognitoAuthorizerArn:
-    Type: 'AWS::SSM::Parameter::Value<String>'
-    Description: Reference to Cognito UserPool for the stage
-    Default: CognitoAuthorizerArn
-  AllowedOrigins:
-    Type: String
-    Description: comma separated list of external clients that are allowed to contact the HTTP APIs, "*" indicates that all origins are allowed
-    Default: '*'
-  SlackSnsArn:
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: '/NVA/Monitoring/SlackSnsArn'
-  ChannelRegisterCacheBucketName:
-    Type: 'String'
-    Default: "channel-register-cache"
-    Description: Name of bucket for channel register cache csv
-
+## More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
+#Globals:
+#  Function:
+#    Timeout: 40
+#    MemorySize: 1798
+#    Runtime: java21
+#    Architectures:
+#      - x86_64
+#    Environment:
+#      Variables:
+#        ALLOWED_ORIGIN: !Ref AllowedOrigins
+#        COGNITO_HOST: !Ref CognitoAuthorizationUri
+#        API_HOST: !Ref ApiDomain
+#        API_DOMAIN: !Ref ApiDomain
+#        CUSTOM_DOMAIN_BASE_PATH: !Ref CustomDomainBasePath
+#        DATAPORTEN_CHANNEL_REGISTRY_BASE_URL: !Ref DataportenChannelRegistryBaseUrl
+#
+#  Api:
+#    Cors:
+#      AllowOrigin: "'*'"
+#      AllowMethods: "'OPTIONS,GET'"
+#      AllowHeaders: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,Access-Control-Allow-Origin'"
+#
+#Parameters:
+#  ApiDomain:
+#    Type: AWS::SSM::Parameter::Value<String>
+#    Default: /NVA/ApiDomain
+#    Description: Domain-name for the backend
+#  DataportenChannelRegistryBaseUrl:
+#    Type: String
+#  CustomDomainBasePath:
+#    Type: String
+#    Description: Base path mapping in CustomDomain
+#    Default: publication-channels-v2
+#  CognitoAuthorizationUri:
+#    Type: 'AWS::SSM::Parameter::Value<String>'
+#    Default: '/NVA/CognitoUri'
+#  CognitoAuthorizerArn:
+#    Type: 'AWS::SSM::Parameter::Value<String>'
+#    Description: Reference to Cognito UserPool for the stage
+#    Default: CognitoAuthorizerArn
+#  AllowedOrigins:
+#    Type: String
+#    Description: comma separated list of external clients that are allowed to contact the HTTP APIs, "*" indicates that all origins are allowed
+#    Default: '*'
+#  SlackSnsArn:
+#    Type: AWS::SSM::Parameter::Value<String>
+#    Default: '/NVA/Monitoring/SlackSnsArn'
+#  ChannelRegisterCacheBucketName:
+#    Type: 'String'
+#    Default: "channel-register-cache"
+#    Description: Name of bucket for channel register cache csv
+#
 Resources:
-
+#
   ApiAccessLogGroup:
     Type: AWS::Logs::LogGroup
-
-  PublicationChannelsApi:
-    Type: AWS::Serverless::Api
-    Properties:
-      CacheClusterEnabled: true
-      CacheClusterSize: "0.5"
-      MethodSettings:
-        - HttpMethod: 'GET'
-          ResourcePath: '/~1journal~1{identifier}~1{year}'
-          CacheTtlInSeconds: 3600
-          CachingEnabled: true
-        - HttpMethod: 'GET'
-          ResourcePath: '/~1series~1{identifier}~1{year}'
-          CacheTtlInSeconds: 3600
-          CachingEnabled: true
-        - HttpMethod: 'GET'
-          ResourcePath: '/~1publisher~1{identifier}~1{year}'
-          CacheTtlInSeconds: 3600
-          CachingEnabled: true
-        - HttpMethod: 'GET'
-          ResourcePath: '/~1journal'
-          CacheTtlInSeconds: 300
-          CachingEnabled: false
-        - HttpMethod: 'GET'
-          ResourcePath: '/~1series'
-          CacheTtlInSeconds: 300
-          CachingEnabled: false
-        - HttpMethod: 'GET'
-          ResourcePath: '/~1publisher'
-          CacheTtlInSeconds: 300
-          CachingEnabled: false
-      DefinitionBody:
-        'Fn::Transform':
-          Name: AWS::Include
-          Parameters:
-            Location: ./docs/openapi.yaml
-      AccessLogSetting:
-        DestinationArn: !GetAtt ApiAccessLogGroup.Arn
-        Format: '{ "apiId": "$context.apiId", "requestId": "$context.requestId", "requestTime": "$context.requestTime", "requestTimeEpoch": "$context.requestTimeEpoch", "httpMethod": "$context.httpMethod", "path": "$context.path", "status": "$context.status",  "error.message": "$context.error.message" }'
-      StageName: Prod
-      Auth:
-        DefaultAuthorizer: NONE
-      EndpointConfiguration:
-        Type: REGIONAL
-
-  LambdaRole:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service: [ lambda.amazonaws.com ]
-            Action: [ 'sts:AssumeRole' ]
-      Policies:
-        - PolicyName: writeLog
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              - Effect: Allow
-                Action:
-                  - logs:CreateLogGroup
-                  - logs:CreateLogStream
-                  - logs:PutLogEvents
-                Resource: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:*'
-        - PolicyName: readSecrets
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              - Effect: Allow
-                Action:
-                  - secretsmanager:GetSecretValue
-                Resource: '*'
-
-  S3ManagedPolicy:
-    Type: AWS::IAM::ManagedPolicy
-    Properties:
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Effect: Allow
-            Action:
-              - s3:Get*
-            Resource:
-              - !Sub "arn:aws:s3:::${ChannelRegisterCacheBucketName}-${AWS::AccountId}/*"
-
+#
+#  PublicationChannelsApi:
+#    Type: AWS::Serverless::Api
+#    Properties:
+#      CacheClusterEnabled: true
+#      CacheClusterSize: "0.5"
+#      MethodSettings:
+#        - HttpMethod: 'GET'
+#          ResourcePath: '/~1journal~1{identifier}~1{year}'
+#          CacheTtlInSeconds: 3600
+#          CachingEnabled: true
+#        - HttpMethod: 'GET'
+#          ResourcePath: '/~1series~1{identifier}~1{year}'
+#          CacheTtlInSeconds: 3600
+#          CachingEnabled: true
+#        - HttpMethod: 'GET'
+#          ResourcePath: '/~1publisher~1{identifier}~1{year}'
+#          CacheTtlInSeconds: 3600
+#          CachingEnabled: true
+#        - HttpMethod: 'GET'
+#          ResourcePath: '/~1journal'
+#          CacheTtlInSeconds: 300
+#          CachingEnabled: false
+#        - HttpMethod: 'GET'
+#          ResourcePath: '/~1series'
+#          CacheTtlInSeconds: 300
+#          CachingEnabled: false
+#        - HttpMethod: 'GET'
+#          ResourcePath: '/~1publisher'
+#          CacheTtlInSeconds: 300
+#          CachingEnabled: false
+#      DefinitionBody:
+#        'Fn::Transform':
+#          Name: AWS::Include
+#          Parameters:
+#            Location: ./docs/openapi.yaml
+#      AccessLogSetting:
+#        DestinationArn: !GetAtt ApiAccessLogGroup.Arn
+#        Format: '{ "apiId": "$context.apiId", "requestId": "$context.requestId", "requestTime": "$context.requestTime", "requestTimeEpoch": "$context.requestTimeEpoch", "httpMethod": "$context.httpMethod", "path": "$context.path", "status": "$context.status",  "error.message": "$context.error.message" }'
+#      StageName: Prod
+#      Auth:
+#        DefaultAuthorizer: NONE
+#      EndpointConfiguration:
+#        Type: REGIONAL
+#
+#  LambdaRole:
+#    Type: AWS::IAM::Role
+#    Properties:
+#      AssumeRolePolicyDocument:
+#        Version: 2012-10-17
+#        Statement:
+#          - Effect: Allow
+#            Principal:
+#              Service: [ lambda.amazonaws.com ]
+#            Action: [ 'sts:AssumeRole' ]
+#      Policies:
+#        - PolicyName: writeLog
+#          PolicyDocument:
+#            Version: 2012-10-17
+#            Statement:
+#              - Effect: Allow
+#                Action:
+#                  - logs:CreateLogGroup
+#                  - logs:CreateLogStream
+#                  - logs:PutLogEvents
+#                Resource: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:*'
+#        - PolicyName: readSecrets
+#          PolicyDocument:
+#            Version: 2012-10-17
+#            Statement:
+#              - Effect: Allow
+#                Action:
+#                  - secretsmanager:GetSecretValue
+#                Resource: '*'
+#
+#  S3ManagedPolicy:
+#    Type: AWS::IAM::ManagedPolicy
+#    Properties:
+#      PolicyDocument:
+#        Version: '2012-10-17'
+#        Statement:
+#          - Effect: Allow
+#            Action:
+#              - s3:Get*
+#            Resource:
+#              - !Sub "arn:aws:s3:::${ChannelRegisterCacheBucketName}-${AWS::AccountId}/*"
+#
 #  FetchJournalByIdentifierAndYearFunction:
 #    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
 #    Properties:
@@ -171,14 +171,14 @@ Resources:
 #          CHANNEL_REGISTER_CACHE_BUCKET: !Ref ChannelRegisterCacheBucket
 #          CHANNEL_REGISTER_CACHE_S3_OBJECT: "cache.csv"
 #          SHOULD_USE_CACHE: "true"
-
+#
 #  FetchJournalByIdentifierAndYearFunctionPermission:
 #    Type: AWS::Lambda::Permission
 #    Properties:
 #      FunctionName: !GetAtt FetchJournalByIdentifierAndYearFunction.Arn
 #      Action: lambda:InvokeFunction
 #      Principal: 'apigateway.amazonaws.com'
-
+#
 #  FetchSeriesByIdentifierAndYearFunction:
 #    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
 #    Properties:
@@ -202,14 +202,14 @@ Resources:
 #          CHANNEL_REGISTER_CACHE_BUCKET: !Ref ChannelRegisterCacheBucket
 #          CHANNEL_REGISTER_CACHE_S3_OBJECT: "cache.csv"
 #          SHOULD_USE_CACHE: "true"
-
+#
 #  FetchSeriesByIdentifierAndYearFunctionPermission:
 #    Type: AWS::Lambda::Permission
 #    Properties:
 #      FunctionName: !GetAtt FetchSeriesByIdentifierAndYearFunction.Arn
 #      Action: lambda:InvokeFunction
 #      Principal: 'apigateway.amazonaws.com'
-
+#
 #  FetchPublisherByIdentifierAndYearFunction:
 #    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
 #    Properties:
@@ -233,188 +233,188 @@ Resources:
 #          CHANNEL_REGISTER_CACHE_BUCKET: !Ref ChannelRegisterCacheBucket
 #          CHANNEL_REGISTER_CACHE_S3_OBJECT: "cache.csv"
 #          SHOULD_USE_CACHE: "true"
-
+#
 #  FetchPublisherByIdentifierAndYearFunctionPermission:
 #    Type: AWS::Lambda::Permission
 #    Properties:
 #      FunctionName: !GetAtt FetchPublisherByIdentifierAndYearFunction.Arn
 #      Action: lambda:InvokeFunction
 #      Principal: 'apigateway.amazonaws.com'
-
-  SearchJournalByQueryFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      Handler: no.sikt.nva.pubchannels.handler.search.journal.SearchJournalByQueryHandler::handleRequest
-      Role: !GetAtt LambdaRole.Arn
-      AutoPublishAlias: live
-      Events:
-        SearchJournalByQueryEvent:
-          Type: Api
-          Properties:
-            RestApiId: !Ref PublicationChannelsApi
-            Path: /journal
-            Method: get
-
-  SearchJournalByQueryFunctionPermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !GetAtt SearchJournalByQueryFunction.Arn
-      Action: lambda:InvokeFunction
-      Principal: 'apigateway.amazonaws.com'
-
-  PublicationChannelsBasePathMapping:
-    Type: AWS::ApiGateway::BasePathMapping
-    Properties:
-      BasePath: !Ref CustomDomainBasePath
-      DomainName: !Ref ApiDomain
-      RestApiId: !Ref PublicationChannelsApi
-      Stage: !Ref PublicationChannelsApi.Stage
-
-  CreateJournalFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      Handler: no.sikt.nva.pubchannels.handler.create.journal.CreateJournalHandler::handleRequest
-      Role: !GetAtt LambdaRole.Arn
-      AutoPublishAlias: live
-      #      SnapStart:
-      #        ApplyOn: PublishedVersions
-      Events:
-        CreateJournalEvent:
-          Type: Api
-          Properties:
-            RestApiId: !Ref PublicationChannelsApi
-            Path: /journal
-            Method: post
-
-  CreateJournalFunctionPermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !GetAtt CreateJournalFunction.Arn
-      Action: lambda:InvokeFunction
-      Principal: 'apigateway.amazonaws.com'
-
-  SearchPublisherByQueryFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      Handler: no.sikt.nva.pubchannels.handler.search.publisher.SearchPublisherByQueryHandler::handleRequest
-      Role: !GetAtt LambdaRole.Arn
-      AutoPublishAlias: live
-      Events:
-        SearchPublisherByQueryEvent:
-          Type: Api
-          Properties:
-            RestApiId: !Ref PublicationChannelsApi
-            Path: /publisher
-            Method: get
-
-  SearchPublisherByQueryFunctionPermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !GetAtt SearchPublisherByQueryFunction.Arn
-      Action: lambda:InvokeFunction
-      Principal: 'apigateway.amazonaws.com'
-
-  CreatePublisherFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      Handler: no.sikt.nva.pubchannels.handler.create.publisher.CreatePublisherHandler::handleRequest
-      Role: !GetAtt LambdaRole.Arn
-      AutoPublishAlias: live
-      #      SnapStart:
-      #        ApplyOn: PublishedVersions
-      Events:
-        CreatePublisherEvent:
-          Type: Api
-          Properties:
-            RestApiId: !Ref PublicationChannelsApi
-            Path: /publisher
-            Method: post
-
-  CreatePublisherFunctionPermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !GetAtt CreatePublisherFunction.Arn
-      Action: lambda:InvokeFunction
-      Principal: 'apigateway.amazonaws.com'
-
-  SearchSeriesByQueryFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      Handler: no.sikt.nva.pubchannels.handler.search.series.SearchSeriesByQueryHandler::handleRequest
-      Role: !GetAtt LambdaRole.Arn
-      AutoPublishAlias: live
-      Events:
-        SearchSeriesByQueryEvent:
-          Type: Api
-          Properties:
-            RestApiId: !Ref PublicationChannelsApi
-            Path: /series
-            Method: get
-
-  SearchSeriesByQueryFunctionPermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !GetAtt SearchSeriesByQueryFunction.Arn
-      Action: lambda:InvokeFunction
-      Principal: 'apigateway.amazonaws.com'
-
-  CreateSeriesFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      Handler: no.sikt.nva.pubchannels.handler.create.series.CreateSeriesHandler::handleRequest
-      Role: !GetAtt LambdaRole.Arn
-      AutoPublishAlias: live
-      #      SnapStart:
-      #        ApplyOn: PublishedVersions
-      Events:
-        CreateSeriesEvent:
-          Type: Api
-          Properties:
-            RestApiId: !Ref PublicationChannelsApi
-            Path: /series
-            Method: post
-
-  CreateSeriesFunctionPermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !GetAtt CreateSeriesFunction.Arn
-      Action: lambda:InvokeFunction
-      Principal: 'apigateway.amazonaws.com'
-
-  DataportenChannelRegistryHealthCheck:
-    Type: AWS::Route53::HealthCheck
-    Properties:
-      HealthCheckConfig:
-        Port: 443
-        Type: HTTPS
-        ResourcePath: /health
-        FullyQualifiedDomainName: !Select [2, !Split ["/", !Ref DataportenChannelRegistryBaseUrl]] # Extracts the domain name from the URL
-        RequestInterval: 30
-        FailureThreshold: 2
-        EnableSNI: true
-
-  DataportenChannelRegistryHealthAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      AlarmName: !Sub External-Dataporten-Channel-Registry-API-HealthCheck-${PublicationChannelsApi} # PublicationChannelsApi is here just to make the name unique
-      AlarmDescription: Check if external Dataporten Channel Registry API is healthy
-      Namespace: AWS/Route53
-      MetricName: HealthCheckStatus
-      Dimensions:
-        - Name: HealthCheckId
-          Value: !GetAtt DataportenChannelRegistryHealthCheck.HealthCheckId
-      Statistic: Minimum
-      Period: 60
-      EvaluationPeriods: 1
-      DatapointsToAlarm: 1
-      Threshold: 1
-      ComparisonOperator: LessThanThreshold
-      AlarmActions:
-        - !Ref SlackSnsArn
-      TreatMissingData: notBreaching
-
-  ChannelRegisterCacheBucket:
-    Type: AWS::S3::Bucket
-    Properties:
-      BucketName: !Sub "${ChannelRegisterCacheBucketName}-${AWS::AccountId}"
-
+#
+#  SearchJournalByQueryFunction:
+#    Type: AWS::Serverless::Function
+#    Properties:
+#      Handler: no.sikt.nva.pubchannels.handler.search.journal.SearchJournalByQueryHandler::handleRequest
+#      Role: !GetAtt LambdaRole.Arn
+#      AutoPublishAlias: live
+#      Events:
+#        SearchJournalByQueryEvent:
+#          Type: Api
+#          Properties:
+#            RestApiId: !Ref PublicationChannelsApi
+#            Path: /journal
+#            Method: get
+#
+#  SearchJournalByQueryFunctionPermission:
+#    Type: AWS::Lambda::Permission
+#    Properties:
+#      FunctionName: !GetAtt SearchJournalByQueryFunction.Arn
+#      Action: lambda:InvokeFunction
+#      Principal: 'apigateway.amazonaws.com'
+#
+#  PublicationChannelsBasePathMapping:
+#    Type: AWS::ApiGateway::BasePathMapping
+#    Properties:
+#      BasePath: !Ref CustomDomainBasePath
+#      DomainName: !Ref ApiDomain
+#      RestApiId: !Ref PublicationChannelsApi
+#      Stage: !Ref PublicationChannelsApi.Stage
+#
+#  CreateJournalFunction:
+#    Type: AWS::Serverless::Function
+#    Properties:
+#      Handler: no.sikt.nva.pubchannels.handler.create.journal.CreateJournalHandler::handleRequest
+#      Role: !GetAtt LambdaRole.Arn
+#      AutoPublishAlias: live
+#      #      SnapStart:
+#      #        ApplyOn: PublishedVersions
+#      Events:
+#        CreateJournalEvent:
+#          Type: Api
+#          Properties:
+#            RestApiId: !Ref PublicationChannelsApi
+#            Path: /journal
+#            Method: post
+#
+#  CreateJournalFunctionPermission:
+#    Type: AWS::Lambda::Permission
+#    Properties:
+#      FunctionName: !GetAtt CreateJournalFunction.Arn
+#      Action: lambda:InvokeFunction
+#      Principal: 'apigateway.amazonaws.com'
+#
+#  SearchPublisherByQueryFunction:
+#    Type: AWS::Serverless::Function
+#    Properties:
+#      Handler: no.sikt.nva.pubchannels.handler.search.publisher.SearchPublisherByQueryHandler::handleRequest
+#      Role: !GetAtt LambdaRole.Arn
+#      AutoPublishAlias: live
+#      Events:
+#        SearchPublisherByQueryEvent:
+#          Type: Api
+#          Properties:
+#            RestApiId: !Ref PublicationChannelsApi
+#            Path: /publisher
+#            Method: get
+#
+#  SearchPublisherByQueryFunctionPermission:
+#    Type: AWS::Lambda::Permission
+#    Properties:
+#      FunctionName: !GetAtt SearchPublisherByQueryFunction.Arn
+#      Action: lambda:InvokeFunction
+#      Principal: 'apigateway.amazonaws.com'
+#
+#  CreatePublisherFunction:
+#    Type: AWS::Serverless::Function
+#    Properties:
+#      Handler: no.sikt.nva.pubchannels.handler.create.publisher.CreatePublisherHandler::handleRequest
+#      Role: !GetAtt LambdaRole.Arn
+#      AutoPublishAlias: live
+#      #      SnapStart:
+#      #        ApplyOn: PublishedVersions
+#      Events:
+#        CreatePublisherEvent:
+#          Type: Api
+#          Properties:
+#            RestApiId: !Ref PublicationChannelsApi
+#            Path: /publisher
+#            Method: post
+#
+#  CreatePublisherFunctionPermission:
+#    Type: AWS::Lambda::Permission
+#    Properties:
+#      FunctionName: !GetAtt CreatePublisherFunction.Arn
+#      Action: lambda:InvokeFunction
+#      Principal: 'apigateway.amazonaws.com'
+#
+#  SearchSeriesByQueryFunction:
+#    Type: AWS::Serverless::Function
+#    Properties:
+#      Handler: no.sikt.nva.pubchannels.handler.search.series.SearchSeriesByQueryHandler::handleRequest
+#      Role: !GetAtt LambdaRole.Arn
+#      AutoPublishAlias: live
+#      Events:
+#        SearchSeriesByQueryEvent:
+#          Type: Api
+#          Properties:
+#            RestApiId: !Ref PublicationChannelsApi
+#            Path: /series
+#            Method: get
+#
+#  SearchSeriesByQueryFunctionPermission:
+#    Type: AWS::Lambda::Permission
+#    Properties:
+#      FunctionName: !GetAtt SearchSeriesByQueryFunction.Arn
+#      Action: lambda:InvokeFunction
+#      Principal: 'apigateway.amazonaws.com'
+#
+#  CreateSeriesFunction:
+#    Type: AWS::Serverless::Function
+#    Properties:
+#      Handler: no.sikt.nva.pubchannels.handler.create.series.CreateSeriesHandler::handleRequest
+#      Role: !GetAtt LambdaRole.Arn
+#      AutoPublishAlias: live
+#      #      SnapStart:
+#      #        ApplyOn: PublishedVersions
+#      Events:
+#        CreateSeriesEvent:
+#          Type: Api
+#          Properties:
+#            RestApiId: !Ref PublicationChannelsApi
+#            Path: /series
+#            Method: post
+#
+#  CreateSeriesFunctionPermission:
+#    Type: AWS::Lambda::Permission
+#    Properties:
+#      FunctionName: !GetAtt CreateSeriesFunction.Arn
+#      Action: lambda:InvokeFunction
+#      Principal: 'apigateway.amazonaws.com'
+#
+#  DataportenChannelRegistryHealthCheck:
+#    Type: AWS::Route53::HealthCheck
+#    Properties:
+#      HealthCheckConfig:
+#        Port: 443
+#        Type: HTTPS
+#        ResourcePath: /health
+#        FullyQualifiedDomainName: !Select [2, !Split ["/", !Ref DataportenChannelRegistryBaseUrl]] # Extracts the domain name from the URL
+#        RequestInterval: 30
+#        FailureThreshold: 2
+#        EnableSNI: true
+#
+#  DataportenChannelRegistryHealthAlarm:
+#    Type: AWS::CloudWatch::Alarm
+#    Properties:
+#      AlarmName: !Sub External-Dataporten-Channel-Registry-API-HealthCheck-${PublicationChannelsApi} # PublicationChannelsApi is here just to make the name unique
+#      AlarmDescription: Check if external Dataporten Channel Registry API is healthy
+#      Namespace: AWS/Route53
+#      MetricName: HealthCheckStatus
+#      Dimensions:
+#        - Name: HealthCheckId
+#          Value: !GetAtt DataportenChannelRegistryHealthCheck.HealthCheckId
+#      Statistic: Minimum
+#      Period: 60
+#      EvaluationPeriods: 1
+#      DatapointsToAlarm: 1
+#      Threshold: 1
+#      ComparisonOperator: LessThanThreshold
+#      AlarmActions:
+#        - !Ref SlackSnsArn
+#      TreatMissingData: notBreaching
+#
+#  ChannelRegisterCacheBucket:
+#    Type: AWS::S3::Bucket
+#    Properties:
+#      BucketName: !Sub "${ChannelRegisterCacheBucketName}-${AWS::AccountId}"
+#

--- a/template.yaml
+++ b/template.yaml
@@ -135,18 +135,15 @@ Resources:
                 Action:
                   - secretsmanager:GetSecretValue
                 Resource: '*'
-
-  S3ManagedPolicy:
-    Type: AWS::IAM::ManagedPolicy
-    Properties:
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Effect: Allow
-            Action:
-              - s3:GetObject
-            Resource:
-              - !Sub "arn:aws:s3:::${ChannelRegisterCacheBucketName}-${AWS::AccountId}/*"
+        - PolicyName: readS3
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                Resource:
+                  - !Sub "arn:aws:s3:::${ChannelRegisterCacheBucketName}-${AWS::AccountId}/*"
 
   FetchJournalByIdentifierAndYearFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction

--- a/template.yaml
+++ b/template.yaml
@@ -145,7 +145,8 @@ Resources:
           - Effect: Allow
             Action:
               - s3:Get*
-            Resource: '*'
+            Resource:
+              - !Sub "arn:aws:s3:::${ChannelRegisterCacheBucketName}-${AWS::AccountId}/*"
 
   FetchJournalByIdentifierAndYearFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction

--- a/template.yaml
+++ b/template.yaml
@@ -52,6 +52,10 @@ Parameters:
   SlackSnsArn:
     Type: AWS::SSM::Parameter::Value<String>
     Default: '/NVA/Monitoring/SlackSnsArn'
+  ChannelRegisterCacheBucketName:
+    Type: 'String'
+    Default: "channel-register-cache"
+    Description: Name of bucket for channel register cache csv
 
 Resources:
 
@@ -148,6 +152,11 @@ Resources:
             RestApiId: !Ref PublicationChannelsApi
             Path: /journal/{identifier}/{year}
             Method: get
+      Environment:
+        Variables:
+          CHANNEL_REGISTER_CACHE_BUCKET: !Ref ChannelRegisterCacheBucket
+          CHANNEL_REGISTER_CACHE_S3_OBJECT: "cache.csv"
+          SHOULD_USE_CACHE: "true"
 
   FetchJournalByIdentifierAndYearFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -172,6 +181,11 @@ Resources:
             RestApiId: !Ref PublicationChannelsApi
             Path: /series/{identifier}/{year}
             Method: get
+      Environment:
+        Variables:
+          CHANNEL_REGISTER_CACHE_BUCKET: !Ref ChannelRegisterCacheBucket
+          CHANNEL_REGISTER_CACHE_S3_OBJECT: "cache.csv"
+          SHOULD_USE_CACHE: "true"
 
   FetchSeriesByIdentifierAndYearFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -196,6 +210,11 @@ Resources:
             RestApiId: !Ref PublicationChannelsApi
             Path: /publisher/{identifier}/{year}
             Method: get
+      Environment:
+        Variables:
+          CHANNEL_REGISTER_CACHE_BUCKET: !Ref ChannelRegisterCacheBucket
+          CHANNEL_REGISTER_CACHE_S3_OBJECT: "cache.csv"
+          SHOULD_USE_CACHE: "true"
 
   FetchPublisherByIdentifierAndYearFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -375,3 +394,9 @@ Resources:
       AlarmActions:
         - !Ref SlackSnsArn
       TreatMissingData: notBreaching
+
+  ChannelRegisterCacheBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub "${ChannelRegisterCacheBucketName}-${AWS::AccountId}"
+

--- a/template.yaml
+++ b/template.yaml
@@ -172,12 +172,12 @@ Resources:
 #          CHANNEL_REGISTER_CACHE_S3_OBJECT: "cache.csv"
 #          SHOULD_USE_CACHE: "true"
 
-  FetchJournalByIdentifierAndYearFunctionPermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !GetAtt FetchJournalByIdentifierAndYearFunction.Arn
-      Action: lambda:InvokeFunction
-      Principal: 'apigateway.amazonaws.com'
+#  FetchJournalByIdentifierAndYearFunctionPermission:
+#    Type: AWS::Lambda::Permission
+#    Properties:
+#      FunctionName: !GetAtt FetchJournalByIdentifierAndYearFunction.Arn
+#      Action: lambda:InvokeFunction
+#      Principal: 'apigateway.amazonaws.com'
 
 #  FetchSeriesByIdentifierAndYearFunction:
 #    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
@@ -203,12 +203,12 @@ Resources:
 #          CHANNEL_REGISTER_CACHE_S3_OBJECT: "cache.csv"
 #          SHOULD_USE_CACHE: "true"
 
-  FetchSeriesByIdentifierAndYearFunctionPermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !GetAtt FetchSeriesByIdentifierAndYearFunction.Arn
-      Action: lambda:InvokeFunction
-      Principal: 'apigateway.amazonaws.com'
+#  FetchSeriesByIdentifierAndYearFunctionPermission:
+#    Type: AWS::Lambda::Permission
+#    Properties:
+#      FunctionName: !GetAtt FetchSeriesByIdentifierAndYearFunction.Arn
+#      Action: lambda:InvokeFunction
+#      Principal: 'apigateway.amazonaws.com'
 
 #  FetchPublisherByIdentifierAndYearFunction:
 #    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
@@ -234,12 +234,12 @@ Resources:
 #          CHANNEL_REGISTER_CACHE_S3_OBJECT: "cache.csv"
 #          SHOULD_USE_CACHE: "true"
 
-  FetchPublisherByIdentifierAndYearFunctionPermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !GetAtt FetchPublisherByIdentifierAndYearFunction.Arn
-      Action: lambda:InvokeFunction
-      Principal: 'apigateway.amazonaws.com'
+#  FetchPublisherByIdentifierAndYearFunctionPermission:
+#    Type: AWS::Lambda::Permission
+#    Properties:
+#      FunctionName: !GetAtt FetchPublisherByIdentifierAndYearFunction.Arn
+#      Action: lambda:InvokeFunction
+#      Principal: 'apigateway.amazonaws.com'
 
   SearchJournalByQueryFunction:
     Type: AWS::Serverless::Function

--- a/template.yaml
+++ b/template.yaml
@@ -136,11 +136,25 @@ Resources:
                   - secretsmanager:GetSecretValue
                 Resource: '*'
 
+  S3ManagedPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:Get*
+            Resource:
+              - !Sub "arn:aws:s3:::channel-register-cache-${AWS::AccountId}/*"
+
   FetchJournalByIdentifierAndYearFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:
       Handler: no.sikt.nva.pubchannels.handler.fetch.journal.FetchJournalByIdentifierAndYearHandler::handleRequest
       Role: !GetAtt LambdaRole.Arn
+      Policies:
+        - !Ref S3ManagedPolicy
       AutoPublishAlias: live
       #      SnapStart:
       #        ApplyOn: PublishedVersions
@@ -170,6 +184,8 @@ Resources:
     Properties:
       Handler: no.sikt.nva.pubchannels.handler.fetch.series.FetchSeriesByIdentifierAndYearHandler::handleRequest
       Role: !GetAtt LambdaRole.Arn
+      Policies:
+        - !Ref S3ManagedPolicy
       AutoPublishAlias: live
       #      SnapStart:
       #        ApplyOn: PublishedVersions
@@ -199,6 +215,8 @@ Resources:
     Properties:
       Handler: no.sikt.nva.pubchannels.handler.fetch.publisher.FetchPublisherByIdentifierAndYearHandler::handleRequest
       Role: !GetAtt LambdaRole.Arn
+      Policies:
+        - !Ref S3ManagedPolicy
       AutoPublishAlias: live
       #      SnapStart:
       #        ApplyOn: PublishedVersions

--- a/template.yaml
+++ b/template.yaml
@@ -146,7 +146,7 @@ Resources:
             Action:
               - s3:Get*
             Resource:
-              - !Sub "arn:aws:s3:::channel-register-cache-${AWS::AccountId}/*"
+              !Ref ChannelRegisterCacheBucket
 
   FetchJournalByIdentifierAndYearFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction

--- a/template.yaml
+++ b/template.yaml
@@ -148,29 +148,29 @@ Resources:
             Resource:
               - !Sub "arn:aws:s3:::${ChannelRegisterCacheBucketName}-${AWS::AccountId}/*"
 
-  FetchJournalByIdentifierAndYearFunction:
-    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
-    Properties:
-      Handler: no.sikt.nva.pubchannels.handler.fetch.journal.FetchJournalByIdentifierAndYearHandler::handleRequest
-      Role: !GetAtt LambdaRole.Arn
-      Policies:
-        - !Ref S3ManagedPolicy
-      AutoPublishAlias: live
-      #      SnapStart:
-      #        ApplyOn: PublishedVersions
-      Timeout: 60
-      Events:
-        FetchJournalByIdentifierAndYearEvent:
-          Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
-          Properties:
-            RestApiId: !Ref PublicationChannelsApi
-            Path: /journal/{identifier}/{year}
-            Method: get
-      Environment:
-        Variables:
-          CHANNEL_REGISTER_CACHE_BUCKET: !Ref ChannelRegisterCacheBucket
-          CHANNEL_REGISTER_CACHE_S3_OBJECT: "cache.csv"
-          SHOULD_USE_CACHE: "true"
+#  FetchJournalByIdentifierAndYearFunction:
+#    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+#    Properties:
+#      Handler: no.sikt.nva.pubchannels.handler.fetch.journal.FetchJournalByIdentifierAndYearHandler::handleRequest
+#      Role: !GetAtt LambdaRole.Arn
+#      Policies:
+#        - !Ref S3ManagedPolicy
+#      AutoPublishAlias: live
+#      #      SnapStart:
+#      #        ApplyOn: PublishedVersions
+#      Timeout: 60
+#      Events:
+#        FetchJournalByIdentifierAndYearEvent:
+#          Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+#          Properties:
+#            RestApiId: !Ref PublicationChannelsApi
+#            Path: /journal/{identifier}/{year}
+#            Method: get
+#      Environment:
+#        Variables:
+#          CHANNEL_REGISTER_CACHE_BUCKET: !Ref ChannelRegisterCacheBucket
+#          CHANNEL_REGISTER_CACHE_S3_OBJECT: "cache.csv"
+#          SHOULD_USE_CACHE: "true"
 
   FetchJournalByIdentifierAndYearFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -179,29 +179,29 @@ Resources:
       Action: lambda:InvokeFunction
       Principal: 'apigateway.amazonaws.com'
 
-  FetchSeriesByIdentifierAndYearFunction:
-    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
-    Properties:
-      Handler: no.sikt.nva.pubchannels.handler.fetch.series.FetchSeriesByIdentifierAndYearHandler::handleRequest
-      Role: !GetAtt LambdaRole.Arn
-      Policies:
-        - !Ref S3ManagedPolicy
-      AutoPublishAlias: live
-      #      SnapStart:
-      #        ApplyOn: PublishedVersions
-      Timeout: 60
-      Events:
-        FetchSeriesByIdentifierAndYearEvent:
-          Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
-          Properties:
-            RestApiId: !Ref PublicationChannelsApi
-            Path: /series/{identifier}/{year}
-            Method: get
-      Environment:
-        Variables:
-          CHANNEL_REGISTER_CACHE_BUCKET: !Ref ChannelRegisterCacheBucket
-          CHANNEL_REGISTER_CACHE_S3_OBJECT: "cache.csv"
-          SHOULD_USE_CACHE: "true"
+#  FetchSeriesByIdentifierAndYearFunction:
+#    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+#    Properties:
+#      Handler: no.sikt.nva.pubchannels.handler.fetch.series.FetchSeriesByIdentifierAndYearHandler::handleRequest
+#      Role: !GetAtt LambdaRole.Arn
+#      Policies:
+#        - !Ref S3ManagedPolicy
+#      AutoPublishAlias: live
+#      #      SnapStart:
+#      #        ApplyOn: PublishedVersions
+#      Timeout: 60
+#      Events:
+#        FetchSeriesByIdentifierAndYearEvent:
+#          Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+#          Properties:
+#            RestApiId: !Ref PublicationChannelsApi
+#            Path: /series/{identifier}/{year}
+#            Method: get
+#      Environment:
+#        Variables:
+#          CHANNEL_REGISTER_CACHE_BUCKET: !Ref ChannelRegisterCacheBucket
+#          CHANNEL_REGISTER_CACHE_S3_OBJECT: "cache.csv"
+#          SHOULD_USE_CACHE: "true"
 
   FetchSeriesByIdentifierAndYearFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -210,29 +210,29 @@ Resources:
       Action: lambda:InvokeFunction
       Principal: 'apigateway.amazonaws.com'
 
-  FetchPublisherByIdentifierAndYearFunction:
-    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
-    Properties:
-      Handler: no.sikt.nva.pubchannels.handler.fetch.publisher.FetchPublisherByIdentifierAndYearHandler::handleRequest
-      Role: !GetAtt LambdaRole.Arn
-      Policies:
-        - !Ref S3ManagedPolicy
-      AutoPublishAlias: live
-      #      SnapStart:
-      #        ApplyOn: PublishedVersions
-      Timeout: 60
-      Events:
-        FetchPublisherByIdentifierAndYearEvent:
-          Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
-          Properties:
-            RestApiId: !Ref PublicationChannelsApi
-            Path: /publisher/{identifier}/{year}
-            Method: get
-      Environment:
-        Variables:
-          CHANNEL_REGISTER_CACHE_BUCKET: !Ref ChannelRegisterCacheBucket
-          CHANNEL_REGISTER_CACHE_S3_OBJECT: "cache.csv"
-          SHOULD_USE_CACHE: "true"
+#  FetchPublisherByIdentifierAndYearFunction:
+#    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+#    Properties:
+#      Handler: no.sikt.nva.pubchannels.handler.fetch.publisher.FetchPublisherByIdentifierAndYearHandler::handleRequest
+#      Role: !GetAtt LambdaRole.Arn
+#      Policies:
+#        - !Ref S3ManagedPolicy
+#      AutoPublishAlias: live
+#      #      SnapStart:
+#      #        ApplyOn: PublishedVersions
+#      Timeout: 60
+#      Events:
+#        FetchPublisherByIdentifierAndYearEvent:
+#          Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+#          Properties:
+#            RestApiId: !Ref PublicationChannelsApi
+#            Path: /publisher/{identifier}/{year}
+#            Method: get
+#      Environment:
+#        Variables:
+#          CHANNEL_REGISTER_CACHE_BUCKET: !Ref ChannelRegisterCacheBucket
+#          CHANNEL_REGISTER_CACHE_S3_OBJECT: "cache.csv"
+#          SHOULD_USE_CACHE: "true"
 
   FetchPublisherByIdentifierAndYearFunctionPermission:
     Type: AWS::Lambda::Permission

--- a/template.yaml
+++ b/template.yaml
@@ -154,7 +154,7 @@ Resources:
       Handler: no.sikt.nva.pubchannels.handler.fetch.journal.FetchJournalByIdentifierAndYearHandler::handleRequest
       Role: !GetAtt LambdaRole.Arn
       Policies:
-        - !Ref S3ManagedPolicy
+        - !GetAtt S3ManagedPolicy.PolicyArn
       AutoPublishAlias: live
       #      SnapStart:
       #        ApplyOn: PublishedVersions

--- a/template.yaml
+++ b/template.yaml
@@ -158,7 +158,7 @@ Resources:
       AutoPublishAlias: live
       #      SnapStart:
       #        ApplyOn: PublishedVersions
-      Timeout: 3
+      Timeout: 60
       Events:
         FetchJournalByIdentifierAndYearEvent:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
@@ -189,7 +189,7 @@ Resources:
       AutoPublishAlias: live
       #      SnapStart:
       #        ApplyOn: PublishedVersions
-      Timeout: 3
+      Timeout: 60
       Events:
         FetchSeriesByIdentifierAndYearEvent:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
@@ -220,7 +220,7 @@ Resources:
       AutoPublishAlias: live
       #      SnapStart:
       #        ApplyOn: PublishedVersions
-      Timeout: 3
+      Timeout: 60
       Events:
         FetchPublisherByIdentifierAndYearEvent:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api

--- a/template.yaml
+++ b/template.yaml
@@ -144,7 +144,7 @@ Resources:
         Statement:
           - Effect: Allow
             Action:
-              - s3:Get*
+              - s3:GetObject
             Resource:
               - !Sub "arn:aws:s3:::${ChannelRegisterCacheBucketName}-${AWS::AccountId}/*"
 


### PR DESCRIPTION
Adding support for cache when fetching publication channels.

- Increasing fetch channel lambdas timeout to 1 minute
- Fetching csv from S3 and fetching channel with matching id. 
- Cached client returns the same response as ChannelRegisterClient
- Response time for cached client is about 12 seconds. 

Next step will be to populate csv in DynamoDb table and read channel from the database, this will improve performance. Implementation in lambda layer will be unchanged. 