### PR TITLE
Np 48099 Fetch serial publication - openapi spec and template

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -65,13 +65,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JournalResponse'
+                $ref: '#/components/schemas/SerialPublication'
               examples:
                 objectExample:
                   $ref: '#/components/examples/JournalResponseExample'
             application/ld+json:
               schema:
-                $ref: '#/components/schemas/JournalResponse'
+                $ref: '#/components/schemas/SerialPublication'
               examples:
                 objectExample:
                   $ref: '#/components/examples/JournalResponseExample'
@@ -179,7 +179,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JournalResponse'
+                $ref: '#/components/schemas/SerialPublication'
         400:
           $ref: '#/components/responses/400'
         502:
@@ -387,13 +387,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Series'
+                $ref: '#/components/schemas/SerialPublication'
               examples:
                 objectExample:
                   $ref: '#/components/examples/SeriesExample'
             application/ld+json:
               schema:
-                $ref: '#/components/schemas/Series'
+                $ref: '#/components/schemas/SerialPublication'
               examples:
                 objectExample:
                   $ref: '#/components/examples/SeriesExample'
@@ -501,9 +501,74 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Series'
+                $ref: '#/components/schemas/SerialPublication'
         400:
           $ref: '#/components/responses/400'
+        502:
+          $ref: '#/components/responses/502'
+  /serial-publication/{identifier}/{year}:
+    get:
+      x-amazon-apigateway-integration:
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${FetchSerialPublicationByIdentifierAndYearFunction.Arn}/invocations
+        httpMethod: POST
+        requestParameters:
+          integration.request.path.identifier:
+            'method.request.path.identifier'
+          integration.request.path.year:
+            'method.request.path.year'
+        cacheKeyParameters:
+          - 'method.request.path.identifier'
+          - 'method.request.path.year'
+        type: "AWS_PROXY"
+      tags:
+        - SerialPublication
+      summary: Fetch journal or series by identifier and year
+      description: Returns a single Journal or Series with information for a specific year
+      operationId: FetchSerialPublicationByIdentifierAndYear
+      parameters:
+        - name: identifier
+          in: path
+          description: identifier of journal/series to return
+          required: true
+          schema:
+            type: string
+          example: '151f411d-68cd-4c7a-9cbb-daf00e0326ce'
+        - name: year
+          in: path
+          description: year for journal/series data
+          required: true
+          schema:
+            type: integer
+            description: can maximum be set to next year
+          example: '1910'
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SerialPublication'
+              examples:
+                objectExample:
+                  $ref: '#/components/examples/JournalResponseExample'
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/SerialPublication'
+              examples:
+                objectExample:
+                  $ref: '#/components/examples/JournalResponseExample'
+        301:
+          description: Moved permanently
+          headers:
+            Location:
+              schema:
+                type: string
+              description: A URI to the new resource
+        400:
+          $ref: '#/components/responses/400'
+        404:
+          $ref: '#/components/responses/404'
         502:
           $ref: '#/components/responses/502'
 
@@ -562,35 +627,7 @@ components:
         hits:
           type: array
           items:
-            $ref: '#/components/schemas/JournalResponse'
-    JournalResponse:
-      type: object
-      properties:
-        '@context':
-          $ref: '#/components/schemas/Context'
-        type:
-          type: string
-          pattern: 'Journal'
-          description: The type of the returned object, always Journal
-        name:
-          $ref: '#/components/schemas/Name'
-        onlineIssn:
-          type: string
-          pattern: '^[0-9]{4}-[0-9]{4}$'
-          description: The ISSN of the online edition of the Journal
-        printIssn:
-          type: string
-          pattern: '^[0-9]{4}-[0-9]{4}$'
-          nullable: true
-          description: The ISSN of the print edition of the Journal
-        scientificValue:
-          $ref: '#/components/schemas/ScientificValue'
-        year:
-          type: string
-          nullable: true
-        sameAs:
-          type: string
-          nullable: true
+            $ref: '#/components/schemas/SerialPublication'
     CreateJournal:
       type: object
       properties:
@@ -694,27 +731,27 @@ components:
         hits:
           type: array
           items:
-            $ref: '#/components/schemas/Series'
-    Series:
+            $ref: '#/components/schemas/SerialPublication'
+    SerialPublication:
       type: object
       properties:
         '@context':
           $ref: '#/components/schemas/Context'
         type:
           type: string
-          pattern: 'Series'
-          description: The type of the returned object, always Series
+          enum: ['Series', 'Journal']
+          description: The type of the returned object, either Series or Journal
         name:
           $ref: '#/components/schemas/Name'
         onlineIssn:
           type: string
           pattern: '^[0-9]{4}-[0-9]{4}$'
-          description: The ISSN of the online edition of the Series
+          description: The ISSN of the online edition of the series/journal
         printIssn:
           type: string
           pattern: '^[0-9]{4}-[0-9]{4}$'
           nullable: true
-          description: The ISSN of the print edition of the Series
+          description: The ISSN of the print edition of the series/journal
         scientificValue:
           $ref: '#/components/schemas/ScientificValue'
         year:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -68,13 +68,13 @@ paths:
                 $ref: '#/components/schemas/SerialPublication'
               examples:
                 objectExample:
-                  $ref: '#/components/examples/JournalResponseExample'
+                  $ref: '#/components/examples/JournalExample'
             application/ld+json:
               schema:
                 $ref: '#/components/schemas/SerialPublication'
               examples:
                 objectExample:
-                  $ref: '#/components/examples/JournalResponseExample'
+                  $ref: '#/components/examples/JournalExample'
         301:
           description: Moved permanently
           headers:
@@ -550,14 +550,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/SerialPublication'
               examples:
-                objectExample:
-                  $ref: '#/components/examples/JournalResponseExample'
+                journal:
+                  $ref: "#/components/examples/JournalExample"
+                series:
+                  $ref: "#/components/examples/SeriesExample"
             application/ld+json:
               schema:
                 $ref: '#/components/schemas/SerialPublication'
               examples:
-                objectExample:
-                  $ref: '#/components/examples/JournalResponseExample'
+                journal:
+                  $ref: "#/components/examples/JournalExample"
+                series:
+                  $ref: "#/components/examples/SeriesExample"
         301:
           description: Moved permanently
           headers:
@@ -739,7 +743,7 @@ components:
           $ref: '#/components/schemas/Context'
         type:
           type: string
-          enum: ['Series', 'Journal']
+          enum: [ 'Series', 'Journal' ]
           description: The type of the returned object, either Series or Journal
         name:
           $ref: '#/components/schemas/Name'
@@ -836,7 +840,7 @@ components:
             printIssn: '4321-4321'
             scientificValue: 'LevelOne'
             sameAs: 'https://kanalregister.hkdir.no/publiseringskanaler/KanalTidsskriftInfo?pid=151f411d-68cd-4c7a-9cbb-daf00e0326ce'
-    JournalResponseExample:
+    JournalExample:
       value:
         '@context': 'https://example.org/context.json'
         id: 'https://example.org/journal/151f411d-68cd-4c7a-9cbb-daf00e0326ce/2010'

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -834,7 +834,7 @@ components:
             name: 'The journal of eternal fury'
             onlineIssn: '1234-1234'
             printIssn: '4321-4321'
-            scientificValue: 'LEVEL_1'
+            scientificValue: 'LevelOne'
             sameAs: 'https://kanalregister.hkdir.no/publiseringskanaler/KanalTidsskriftInfo?pid=151f411d-68cd-4c7a-9cbb-daf00e0326ce'
     JournalResponseExample:
       value:
@@ -844,7 +844,7 @@ components:
         name: 'The journal of eternal fury'
         onlineIssn: '1234-1234'
         printIssn: '4321-4321'
-        scientificValue: 'LEVEL_1'
+        scientificValue: 'LevelOne'
         year: '1900'
         sameAs: 'https://kanalregister.hkdir.no/publiseringskanaler/KanalTidsskriftInfo?pid=151f411d-68cd-4c7a-9cbb-daf00e0326ce'
       summary: A sample journal
@@ -869,7 +869,7 @@ components:
             name: 'The publisher of eternal fury'
             onlineIssn: '1234-1234'
             printIssn: '4321-4321'
-            scientificValue: 'LEVEL_1'
+            scientificValue: 'LevelOne'
             sameAs: 'https://kanalregister.hkdir.no/publiseringskanaler/KanalTidsskriftInfo?pid=151f411d-68cd-4c7a-9cbb-daf00e0326ce'
     CreatePublisherExample:
       value:
@@ -883,7 +883,7 @@ components:
         type: 'Publisher'
         name: 'The publisher of eternal fury'
         isbnPrefix: '12345-1234567'
-        scientificValue: 'LEVEL_1'
+        scientificValue: 'LevelOne'
         year: '1900'
         sameAs: 'https://kanalregister.hkdir.no/publiseringskanaler/KanalTidsskriftInfo?pid=151f411d-68cd-4c7a-9cbb-daf00e0326ce'
       summary: A sample publisher
@@ -901,7 +901,7 @@ components:
             name: 'The series of eternal fury'
             onlineIssn: '1234-1234'
             printIssn: '4321-4321'
-            scientificValue: 'LEVEL_1'
+            scientificValue: 'LevelOne'
             sameAs: 'https://kanalregister.hkdir.no/publiseringskanaler/KanalTidsskriftInfo?pid=151f411d-68cd-4c7a-9cbb-daf00e0326ce'
     SeriesExample:
       value:
@@ -910,7 +910,7 @@ components:
         name: 'The series of eternal fury'
         onlineIssn: '1234-1234'
         printIssn: '4321-4321'
-        scientificValue: 'LEVEL_1'
+        scientificValue: 'LevelOne'
         year: '1900'
         sameAs: 'https://kanalregister.hkdir.no/publiseringskanaler/KanalTidsskriftInfo?pid=151f411d-68cd-4c7a-9cbb-daf00e0326ce'
       summary: A sample series

--- a/template.yaml
+++ b/template.yaml
@@ -7,7 +7,7 @@ Description: >
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:
-    Timeout: 40
+    Timeout: 30
     MemorySize: 1798
     Runtime: java21
     Architectures:
@@ -215,19 +215,15 @@ Resources:
           CHANNEL_REGISTER_CACHE_S3_OBJECT: "cache.csv"
 
   FetchJournalByIdentifierAndYearFunction:
-    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+    Type: AWS::Serverless::Function
     Properties:
       Handler: no.sikt.nva.pubchannels.handler.fetch.journal.FetchJournalByIdentifierAndYearHandler::handleRequest
       Policies:
         - !GetAtt GetItemDynamoDbPolicy.PolicyArn
         - !GetAtt AppConfigActionsPolicy.PolicyArn
-      #      AutoPublishAlias: live
-      #      SnapStart:
-      #        ApplyOn: PublishedVersions
-      Timeout: 60
       Events:
         FetchJournalByIdentifierAndYearEvent:
-          Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+          Type: Api
           Properties:
             RestApiId: !Ref PublicationChannelsApi
             Path: /journal/{identifier}/{year}
@@ -254,7 +250,6 @@ Resources:
       Policies:
         - !GetAtt GetItemDynamoDbPolicy.PolicyArn
         - !GetAtt AppConfigActionsPolicy.PolicyArn
-      Timeout: 30
       Events:
         FetchSerialPublicationByIdentifierAndYearEvent:
           Type: Api
@@ -278,19 +273,15 @@ Resources:
       Principal: 'apigateway.amazonaws.com'
 
   FetchSeriesByIdentifierAndYearFunction:
-    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+    Type: AWS::Serverless::Function
     Properties:
       Handler: no.sikt.nva.pubchannels.handler.fetch.series.FetchSeriesByIdentifierAndYearHandler::handleRequest
       Policies:
         - !GetAtt GetItemDynamoDbPolicy.PolicyArn
         - !GetAtt AppConfigActionsPolicy.PolicyArn
-      #      AutoPublishAlias: live
-      #      SnapStart:
-      #        ApplyOn: PublishedVersions
-      Timeout: 60
       Events:
         FetchSeriesByIdentifierAndYearEvent:
-          Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+          Type: Api
           Properties:
             RestApiId: !Ref PublicationChannelsApi
             Path: /series/{identifier}/{year}
@@ -311,19 +302,15 @@ Resources:
       Principal: 'apigateway.amazonaws.com'
 
   FetchPublisherByIdentifierAndYearFunction:
-    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+    Type: AWS::Serverless::Function
     Properties:
       Handler: no.sikt.nva.pubchannels.handler.fetch.publisher.FetchPublisherByIdentifierAndYearHandler::handleRequest
       Policies:
         - !GetAtt GetItemDynamoDbPolicy.PolicyArn
         - !GetAtt AppConfigActionsPolicy.PolicyArn
-      #      AutoPublishAlias: live
-      #      SnapStart:
-      #        ApplyOn: PublishedVersions
-      Timeout: 60
       Events:
         FetchPublisherByIdentifierAndYearEvent:
-          Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+          Type: Api
           Properties:
             RestApiId: !Ref PublicationChannelsApi
             Path: /publisher/{identifier}/{year}
@@ -379,8 +366,6 @@ Resources:
         - !GetAtt GetItemDynamoDbPolicy.PolicyArn
         - !GetAtt ReadSecretsPolicy.PolicyArn
       AutoPublishAlias: live
-      #      SnapStart:
-      #        ApplyOn: PublishedVersions
       Events:
         CreateJournalEvent:
           Type: Api

--- a/template.yaml
+++ b/template.yaml
@@ -247,6 +247,36 @@ Resources:
       Action: lambda:InvokeFunction
       Principal: 'apigateway.amazonaws.com'
 
+  FetchSerialPublicationByIdentifierAndYearFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: no.sikt.nva.pubchannels.handler.fetch.serialpublication.FetchSerialPublicationByIdentifierAndYearHandler::handleRequest
+      Policies:
+        - !GetAtt GetItemDynamoDbPolicy.PolicyArn
+        - !GetAtt AppConfigActionsPolicy.PolicyArn
+      Timeout: 30
+      Events:
+        FetchSerialPublicationByIdentifierAndYearEvent:
+          Type: Api
+          Properties:
+            RestApiId: !Ref PublicationChannelsApi
+            Path: /serial-publication/{identifier}/{year}
+            Method: get
+      Environment:
+        Variables:
+          TABLE_NAME: !Ref ChannelRegisterCacheTable
+          APPLICATION_CONFIG_NAME: !Ref ApplicationConfigName
+          APPLICATION_CONFIG_PROFILE_NAME: !Ref ConfigurationProfileName
+          APPLICATION_CONFIG_ENVIRONMENT_NAME: !Ref EnvironmentName
+          APPLICATION_ID: !Ref ApplicationIdName
+
+  FetchSerialPublicationByIdentifierAndYearFunctionPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt FetchSerialPublicationByIdentifierAndYearFunction.Arn
+      Action: lambda:InvokeFunction
+      Principal: 'apigateway.amazonaws.com'
+
   FetchSeriesByIdentifierAndYearFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:


### PR DESCRIPTION
- Global timeout in template set to 30 (Due to ApiGateway timeout limit)
- Added `FetchSerialPublicationByIdentifierAndYearFunction` in template and openapi spec
- Removed unnecessary comments in template