### PR TITLE
[np-48010] Refactor tests for search serial publication

### DIFF
--- a/src/main/java/no/sikt/nva/pubchannels/channelregistry/ChannelRegistryClient.java
+++ b/src/main/java/no/sikt/nva/pubchannels/channelregistry/ChannelRegistryClient.java
@@ -152,7 +152,7 @@ public class ChannelRegistryClient implements PublicationChannelClient {
     private HttpRequest createFindPublicationChannelRequest(String pathElement, Map<String, String> queryParams) {
         return HttpRequest.newBuilder()
                    .header(ACCEPT, CONTENT_TYPE_APPLICATION_JSON)
-                   .uri(addQueryParamameters(constructUri(pathElement, SEARCH_PATH_ELEMENT), queryParams))
+                          .uri(addQueryParameters(constructUri(pathElement, SEARCH_PATH_ELEMENT), queryParams))
                    .GET()
                    .build();
     }
@@ -199,7 +199,7 @@ public class ChannelRegistryClient implements PublicationChannelClient {
                    .getUri();
     }
 
-    private URI addQueryParamameters(URI uri, Map<String, String> queryParameters) {
+    private URI addQueryParameters(URI uri, Map<String, String> queryParameters) {
         return UriWrapper.fromUri(uri)
                    .addQueryParameters(queryParameters)
                    .getUri();

--- a/src/main/java/no/sikt/nva/pubchannels/channelregistry/ChannelRegistryClient.java
+++ b/src/main/java/no/sikt/nva/pubchannels/channelregistry/ChannelRegistryClient.java
@@ -134,8 +134,8 @@ public class ChannelRegistryClient implements PublicationChannelClient {
         if (e instanceof InterruptedException) {
             LOGGER.error("Thread interrupted when fetching: {}", uri, e);
             Thread.currentThread().interrupt();
-        } else if (e instanceof ApiGatewayException) {
-            return (ApiGatewayException) e;
+        } else if (e instanceof ApiGatewayException apiGatewayException) {
+            return apiGatewayException;
         }
         LOGGER.error("Unable to reach upstream: {}", uri, e);
         return new BadGatewayException("Unable to reach upstream!");

--- a/src/test/java/no/sikt/nva/pubchannels/handler/TestChannel.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/TestChannel.java
@@ -111,17 +111,6 @@ public record TestChannel(String identifier, Integer year, String name, Scientif
                                type);
     }
 
-    public String asChannelRegistryJournalBodyWithoutLevel() {
-        return new ChannelRegistrySerialPublication(identifier,
-                                                    name,
-                                                    getOnlineIssnValue(),
-                                                    getPrintIssnValue(),
-                                                    null,
-                                                    sameAs,
-                                                    discontinued,
-                                                    type).toJsonString();
-    }
-
     public String asChannelRegistrySerialPublicationBody() {
         return new ChannelRegistrySerialPublication(identifier,
                                                     name,
@@ -192,10 +181,6 @@ public record TestChannel(String identifier, Integer year, String name, Scientif
                                 reviewNotice);
     }
 
-    public String getIdentifier() {
-        return identifier;
-    }
-
     public String asChannelRegistrySeriesBodyWithoutLevel() {
         return new ChannelRegistrySerialPublication(identifier,
                                                     name,
@@ -220,15 +205,15 @@ public record TestChannel(String identifier, Integer year, String name, Scientif
                                         isNull(reviewNotice) ? null : reviewNotice.comments().get("en"));
     }
 
-    private String getOnlineIssnValue() {
+    public String getOnlineIssnValue() {
         return nonNull(onlineIssn) ? onlineIssn.value() : null;
     }
 
-    private String getPrintIssnValue() {
+    public String getPrintIssnValue() {
         return nonNull(printIssn) ? printIssn.value() : null;
     }
 
-    private String getIsbnPrefix() {
+    public String getIsbnPrefix() {
         return nonNull(isbnPrefix) ? isbnPrefix.value() : null;
     }
 

--- a/src/test/java/no/sikt/nva/pubchannels/handler/TestUtils.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/TestUtils.java
@@ -144,15 +144,6 @@ public final class TestUtils {
         return queryParams;
     }
 
-    public static StringBuilder getChannelRegistryRequestUrl(String channelRegistryPath, String... queryValue) {
-        var url = new StringBuilder("/" + channelRegistryPath + "/channels");
-        for (int i = 0; i < queryValue.length; i = i + 2) {
-            url.append(i == 0 ? "?" : "&");
-            url.append(queryValue[i]).append("=").append(queryValue[i + 1]);
-        }
-        return url;
-    }
-
     public static ChannelRegistryClient setupInterruptedClient() throws IOException, InterruptedException {
         var httpClient = mock(HttpClient.class);
         when(httpClient.send(any(), any())).thenThrow(new InterruptedException());

--- a/src/test/java/no/sikt/nva/pubchannels/handler/TestUtils.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/TestUtils.java
@@ -4,6 +4,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static java.util.Objects.nonNull;
 import static no.sikt.nva.pubchannels.HttpHeaders.ACCEPT;
 import static no.sikt.nva.pubchannels.TestConstants.API_DOMAIN;
 import static no.sikt.nva.pubchannels.TestConstants.CUSTOM_DOMAIN_BASE_PATH;
@@ -136,7 +137,9 @@ public final class TestUtils {
     public static Map<String, StringValuePattern> getStringStringValuePatternHashMap(String... queryValue) {
         var queryParams = new HashMap<String, StringValuePattern>();
         for (int i = 0; i < queryValue.length; i = i + 2) {
-            queryParams.put(queryValue[i], equalTo(queryValue[i + 1]));
+            if (nonNull(queryValue[i + 1])) {
+                queryParams.put(queryValue[i], equalTo(queryValue[i + 1]));
+            }
         }
         return queryParams;
     }
@@ -168,7 +171,7 @@ public final class TestUtils {
 
     public static URI constructPublicationChannelUri(String pathElement, Map<String, String> queryParams) {
         var uri = new UriWrapper(HTTPS, API_DOMAIN).addChild(CUSTOM_DOMAIN_BASE_PATH, pathElement).getUri();
-        if (Objects.nonNull(queryParams)) {
+        if (nonNull(queryParams)) {
             return UriWrapper.fromUri(uri).addQueryParameters(queryParams).getUri();
         }
         return uri;

--- a/src/test/java/no/sikt/nva/pubchannels/handler/fetch/journal/FetchJournalByIdentifierAndYearHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/fetch/journal/FetchJournalByIdentifierAndYearHandlerTest.java
@@ -1,8 +1,9 @@
 package no.sikt.nva.pubchannels.handler.fetch.journal;
 
+import static no.sikt.nva.pubchannels.TestConstants.API_DOMAIN;
+import static no.sikt.nva.pubchannels.TestConstants.CUSTOM_DOMAIN_BASE_PATH;
 import static no.sikt.nva.pubchannels.TestConstants.JOURNAL_PATH;
 import static no.sikt.nva.pubchannels.TestConstants.JOURNAL_TYPE;
-import java.net.URI;
 import no.sikt.nva.pubchannels.channelregistry.ChannelRegistryClient;
 import no.sikt.nva.pubchannels.channelregistrycache.db.service.CacheService;
 import no.sikt.nva.pubchannels.handler.PublicationChannelClient;
@@ -11,6 +12,7 @@ import no.sikt.nva.pubchannels.handler.fetch.FetchByIdentifierAndYearHandler;
 import no.sikt.nva.pubchannels.handler.model.SerialPublicationDto;
 import no.sikt.nva.pubchannels.utils.AppConfig;
 import nva.commons.core.Environment;
+import nva.commons.core.paths.UriWrapper;
 import org.junit.jupiter.api.BeforeEach;
 
 class FetchJournalByIdentifierAndYearHandlerTest extends BaseFetchSerialPublicationByIdentifierAndYearHandlerTest {
@@ -40,6 +42,9 @@ class FetchJournalByIdentifierAndYearHandlerTest extends BaseFetchSerialPublicat
         this.type = JOURNAL_TYPE;
         this.customChannelPath = JOURNAL_PATH;
         this.channelRegistryPathElement = "/findjournal/";
-        this.selfBaseUri = URI.create("https://localhost/publication-channels/" + JOURNAL_PATH);
+        this.selfBaseUri = UriWrapper.fromHost(API_DOMAIN)
+                                     .addChild(CUSTOM_DOMAIN_BASE_PATH)
+                                     .addChild(JOURNAL_PATH)
+                                     .getUri();
     }
 }

--- a/src/test/java/no/sikt/nva/pubchannels/handler/fetch/publisher/FetchPublisherByIdentifierAndYearHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/fetch/publisher/FetchPublisherByIdentifierAndYearHandlerTest.java
@@ -4,6 +4,8 @@ import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static no.sikt.nva.pubchannels.HttpHeaders.CONTENT_TYPE;
 import static no.sikt.nva.pubchannels.TestConstants.ACCESS_CONTROL_ALLOW_ORIGIN;
+import static no.sikt.nva.pubchannels.TestConstants.API_DOMAIN;
+import static no.sikt.nva.pubchannels.TestConstants.CUSTOM_DOMAIN_BASE_PATH;
 import static no.sikt.nva.pubchannels.TestConstants.LOCATION;
 import static no.sikt.nva.pubchannels.TestConstants.PUBLISHER_PATH;
 import static no.sikt.nva.pubchannels.TestConstants.WILD_CARD;
@@ -46,7 +48,11 @@ import org.zalando.problem.Problem;
 class FetchPublisherByIdentifierAndYearHandlerTest extends FetchByIdentifierAndYearHandlerTest {
 
     private static final String PUBLISHER_IDENTIFIER_FROM_CACHE = "09D6F92E-B0F6-4B62-90AB-1B9E767E9E11";
-    private static final String SELF_URI_BASE = "https://localhost/publication-channels/" + PUBLISHER_PATH;
+    private static final String SELF_URI_BASE = UriWrapper.fromHost(API_DOMAIN)
+                                                          .addChild(CUSTOM_DOMAIN_BASE_PATH)
+                                                          .addChild(PUBLISHER_PATH)
+                                                          .getUri()
+                                                          .toString();
 
     @Override
     protected FetchByIdentifierAndYearHandler<Void, ?> createHandler(ChannelRegistryClient publicationChannelClient) {

--- a/src/test/java/no/sikt/nva/pubchannels/handler/fetch/serialpublication/FetchSerialPublicationByIdentifierAndYearHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/fetch/serialpublication/FetchSerialPublicationByIdentifierAndYearHandlerTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public class FetchSerialPublicationByIdentifierAndYearHandlerTest extends
+class FetchSerialPublicationByIdentifierAndYearHandlerTest extends
                                                                   BaseFetchSerialPublicationByIdentifierAndYearHandlerTest {
 
     @Override

--- a/src/test/java/no/sikt/nva/pubchannels/handler/fetch/serialpublication/FetchSerialPublicationByIdentifierAndYearHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/fetch/serialpublication/FetchSerialPublicationByIdentifierAndYearHandlerTest.java
@@ -1,6 +1,8 @@
 package no.sikt.nva.pubchannels.handler.fetch.serialpublication;
 
 import static java.net.HttpURLConnection.HTTP_OK;
+import static no.sikt.nva.pubchannels.TestConstants.API_DOMAIN;
+import static no.sikt.nva.pubchannels.TestConstants.CUSTOM_DOMAIN_BASE_PATH;
 import static no.sikt.nva.pubchannels.TestConstants.JOURNAL_TYPE;
 import static no.sikt.nva.pubchannels.TestConstants.SERIAL_PUBLICATION_PATH;
 import static no.sikt.nva.pubchannels.TestConstants.SERIES_TYPE;
@@ -11,7 +13,6 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import com.google.common.net.MediaType;
 import java.io.IOException;
-import java.net.URI;
 import java.util.UUID;
 import no.sikt.nva.pubchannels.channelregistry.ChannelRegistryClient;
 import no.sikt.nva.pubchannels.channelregistrycache.db.service.CacheService;
@@ -22,6 +23,7 @@ import no.sikt.nva.pubchannels.handler.model.SerialPublicationDto;
 import no.sikt.nva.pubchannels.utils.AppConfig;
 import nva.commons.apigateway.GatewayResponse;
 import nva.commons.core.Environment;
+import nva.commons.core.paths.UriWrapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -55,8 +57,10 @@ public class FetchSerialPublicationByIdentifierAndYearHandlerTest extends
                                                                                          false));
         this.type = JOURNAL_TYPE;
         this.customChannelPath = SERIAL_PUBLICATION_PATH;
-        this.selfBaseUri = URI.create(
-            "https://localhost/publication-channels/" + SERIAL_PUBLICATION_PATH);
+        this.selfBaseUri = UriWrapper.fromHost(API_DOMAIN)
+                                     .addChild(CUSTOM_DOMAIN_BASE_PATH)
+                                     .addChild(SERIAL_PUBLICATION_PATH)
+                                     .getUri();
         this.channelRegistryPathElement = "/findjournalserie/";
     }
 

--- a/src/test/java/no/sikt/nva/pubchannels/handler/fetch/series/FetchSeriesByIdentifierAndYearHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/fetch/series/FetchSeriesByIdentifierAndYearHandlerTest.java
@@ -1,8 +1,9 @@
 package no.sikt.nva.pubchannels.handler.fetch.series;
 
+import static no.sikt.nva.pubchannels.TestConstants.API_DOMAIN;
+import static no.sikt.nva.pubchannels.TestConstants.CUSTOM_DOMAIN_BASE_PATH;
 import static no.sikt.nva.pubchannels.TestConstants.SERIES_PATH;
 import static no.sikt.nva.pubchannels.TestConstants.SERIES_TYPE;
-import java.net.URI;
 import no.sikt.nva.pubchannels.channelregistry.ChannelRegistryClient;
 import no.sikt.nva.pubchannels.channelregistrycache.db.service.CacheService;
 import no.sikt.nva.pubchannels.handler.PublicationChannelClient;
@@ -11,6 +12,7 @@ import no.sikt.nva.pubchannels.handler.fetch.FetchByIdentifierAndYearHandler;
 import no.sikt.nva.pubchannels.handler.model.SerialPublicationDto;
 import no.sikt.nva.pubchannels.utils.AppConfig;
 import nva.commons.core.Environment;
+import nva.commons.core.paths.UriWrapper;
 import org.junit.jupiter.api.BeforeEach;
 
 class FetchSeriesByIdentifierAndYearHandlerTest extends BaseFetchSerialPublicationByIdentifierAndYearHandlerTest {
@@ -39,7 +41,10 @@ class FetchSeriesByIdentifierAndYearHandlerTest extends BaseFetchSerialPublicati
                                                                           super.getAppConfigWithCacheEnabled(false));
         this.type = SERIES_TYPE;
         this.customChannelPath = SERIES_PATH;
-        this.selfBaseUri = URI.create("https://localhost/publication-channels/" + SERIES_PATH);
+        this.selfBaseUri = UriWrapper.fromHost(API_DOMAIN)
+                                     .addChild(CUSTOM_DOMAIN_BASE_PATH)
+                                     .addChild(SERIES_PATH)
+                                     .getUri();
         this.channelRegistryPathElement = "/findseries/";
     }
 }

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/BaseSearchSerialPublicationByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/BaseSearchSerialPublicationByQueryHandlerTest.java
@@ -1,0 +1,85 @@
+package no.sikt.nva.pubchannels.handler.search;
+
+import static java.util.Objects.nonNull;
+import static no.sikt.nva.pubchannels.HttpHeaders.CONTENT_TYPE;
+import static no.sikt.nva.pubchannels.TestConstants.DEFAULT_OFFSET_INT;
+import static no.sikt.nva.pubchannels.TestConstants.DEFAULT_SIZE_INT;
+import static no.sikt.nva.pubchannels.handler.TestUtils.constructPublicationChannelUri;
+import static no.sikt.nva.pubchannels.handler.TestUtils.constructRequest;
+import static no.sikt.nva.pubchannels.handler.TestUtils.randomYear;
+import static no.unit.nva.testutils.RandomDataGenerator.objectMapper;
+import static no.unit.nva.testutils.RandomDataGenerator.randomIssn;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.net.MediaType;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import no.sikt.nva.pubchannels.handler.TestChannel;
+import no.sikt.nva.pubchannels.handler.model.SerialPublicationDto;
+import no.unit.nva.commons.pagination.PaginatedSearchResult;
+import no.unit.nva.stubs.FakeContext;
+import nva.commons.apigateway.GatewayResponse;
+import nva.commons.apigateway.exceptions.UnprocessableContentException;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public abstract class BaseSearchSerialPublicationByQueryHandlerTest extends SearchByQueryHandlerTest {
+    private static final Context context = new FakeContext();
+    private static final TypeReference<PaginatedSearchResult<SerialPublicationDto>> TYPE_REF = new TypeReference<>() {
+    };
+    protected String type;
+    protected URI selfBaseUri;
+
+    @ParameterizedTest(name = "Should return requested media type \"{0}\"")
+    @MethodSource("no.sikt.nva.pubchannels.handler.TestUtils#mediaTypeProvider")
+    void shouldReturnContentNegotiatedContentWhenRequested(MediaType mediaType)
+        throws IOException, UnprocessableContentException {
+        var year = randomYear();
+        var issn = randomIssn();
+        var testChannel = new TestChannel(year, UUID.randomUUID().toString(), type).withPrintIssn(issn);
+        mockChannelRegistryResponse(year, issn, List.of(testChannel.asChannelRegistrySerialPublicationBody()));
+        var input = constructRequest(Map.of("year", year, "query", issn), mediaType);
+
+        this.handlerUnderTest.handleRequest(input, output, context);
+        var response = GatewayResponse.fromOutputStream(output, PaginatedSearchResult.class);
+        var pagesSearchResult = objectMapper.readValue(response.getBody(), TYPE_REF);
+        var contentType = response.getHeaders().get(CONTENT_TYPE);
+
+        var expectedMediaType =
+            mediaType.equals(MediaType.ANY_TYPE) ? MediaType.JSON_UTF_8.toString() : mediaType.toString();
+        var expectedSearchResult = getExpectedSearchResult(year, issn, testChannel);
+        assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
+        assertThat(contentType, is(equalTo(expectedMediaType)));
+        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
+    }
+
+    private PaginatedSearchResult<SerialPublicationDto> getExpectedSearchResult(String year,
+                                                                                       String printIssn,
+                                                                                       TestChannel testChannel)
+        throws UnprocessableContentException {
+        var expectedParams = new HashMap<String, String>();
+        expectedParams.put("query", printIssn);
+        if (nonNull(year)) {
+            expectedParams.put("year", year);
+        }
+
+        var expectedHits = List.of(testChannel.asSerialPublicationDto(selfBaseUri, year));
+
+        return PaginatedSearchResult.create(constructPublicationChannelUri(testChannel.type(), expectedParams),
+                                            DEFAULT_OFFSET_INT,
+                                            DEFAULT_SIZE_INT,
+                                            expectedHits.size(),
+                                            expectedHits);
+    }
+
+}
+

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/BaseSearchSerialPublicationByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/BaseSearchSerialPublicationByQueryHandlerTest.java
@@ -80,11 +80,37 @@ public abstract class BaseSearchSerialPublicationByQueryHandlerTest extends Sear
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
     }
 
+    @Test
+    void shouldReturnResultWithRequestedYearIfThirdPartyDoesNotProvideYear()
+        throws IOException, UnprocessableContentException {
+        var year = randomYear();
+        var issn = randomIssn();
+        var expectedSearchResult = getExpectedPaginatedSearchResultIssnSearchThirdPartyDoesNotProvideYear(year, issn);
+
+        var input = constructRequest(Map.of("year", year, "query", issn), MediaType.ANY_TYPE);
+
+        this.handlerUnderTest.handleRequest(input, output, context);
+
+        var response = GatewayResponse.fromOutputStream(output, PaginatedSearchResult.class);
+        var pagesSearchResult = objectMapper.readValue(response.getBody(), TYPE_REF);
+
+        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
+        assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
+    }
+
     private PaginatedSearchResult<SerialPublicationDto> getExpectedPaginatedSearchResultIssnSearch(
         String year, String printIssn)
         throws UnprocessableContentException {
         var pid = UUID.randomUUID().toString();
         var testChannel = new TestChannel(year, pid, type).withPrintIssn(printIssn);
+        return mockChannelFoundAndReturnExpectedResponse(year, printIssn, testChannel);
+    }
+
+    private PaginatedSearchResult<SerialPublicationDto> getExpectedPaginatedSearchResultIssnSearchThirdPartyDoesNotProvideYear(
+        String year, String printIssn)
+        throws UnprocessableContentException {
+        var pid = UUID.randomUUID().toString();
+        var testChannel = new TestChannel(null, pid, type).withPrintIssn(printIssn);
         return mockChannelFoundAndReturnExpectedResponse(year, printIssn, testChannel);
     }
 

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/BaseSearchSerialPublicationByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/BaseSearchSerialPublicationByQueryHandlerTest.java
@@ -19,7 +19,6 @@ import static org.hamcrest.Matchers.containsStringIgnoringCase;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.net.MediaType;
 import java.io.IOException;
@@ -32,7 +31,6 @@ import java.util.UUID;
 import no.sikt.nva.pubchannels.handler.TestChannel;
 import no.sikt.nva.pubchannels.handler.model.SerialPublicationDto;
 import no.unit.nva.commons.pagination.PaginatedSearchResult;
-import no.unit.nva.stubs.FakeContext;
 import nva.commons.apigateway.GatewayResponse;
 import nva.commons.apigateway.exceptions.UnprocessableContentException;
 import nva.commons.core.paths.UriWrapper;
@@ -43,7 +41,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 public abstract class BaseSearchSerialPublicationByQueryHandlerTest extends SearchByQueryHandlerTest {
 
-    private static final Context context = new FakeContext();
     private static final TypeReference<PaginatedSearchResult<SerialPublicationDto>> TYPE_REF = new TypeReference<>() {
     };
     // Test data

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/BaseSearchSerialPublicationByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/BaseSearchSerialPublicationByQueryHandlerTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 public abstract class BaseSearchSerialPublicationByQueryHandlerTest extends SearchByQueryHandlerTest {
+
     private static final Context context = new FakeContext();
     private static final TypeReference<PaginatedSearchResult<SerialPublicationDto>> TYPE_REF = new TypeReference<>() {
     };
@@ -63,8 +64,8 @@ public abstract class BaseSearchSerialPublicationByQueryHandlerTest extends Sear
     }
 
     private PaginatedSearchResult<SerialPublicationDto> getExpectedSearchResult(String year,
-                                                                                       String printIssn,
-                                                                                       TestChannel testChannel)
+                                                                                String printIssn,
+                                                                                TestChannel testChannel)
         throws UnprocessableContentException {
         var expectedParams = new HashMap<String, String>();
         expectedParams.put("query", printIssn);
@@ -80,6 +81,5 @@ public abstract class BaseSearchSerialPublicationByQueryHandlerTest extends Sear
                                             expectedHits.size(),
                                             expectedHits);
     }
-
 }
 

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/BaseSearchSerialPublicationByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/BaseSearchSerialPublicationByQueryHandlerTest.java
@@ -4,11 +4,14 @@ import static java.util.Objects.nonNull;
 import static no.sikt.nva.pubchannels.HttpHeaders.CONTENT_TYPE;
 import static no.sikt.nva.pubchannels.TestConstants.DEFAULT_OFFSET_INT;
 import static no.sikt.nva.pubchannels.TestConstants.DEFAULT_SIZE_INT;
+import static no.sikt.nva.pubchannels.TestConstants.ISSN_QUERY_PARAM;
+import static no.sikt.nva.pubchannels.TestConstants.NAME_QUERY_PARAM;
 import static no.sikt.nva.pubchannels.handler.TestUtils.constructPublicationChannelUri;
 import static no.sikt.nva.pubchannels.handler.TestUtils.constructRequest;
 import static no.sikt.nva.pubchannels.handler.TestUtils.randomYear;
 import static no.unit.nva.testutils.RandomDataGenerator.objectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.randomIssn;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.core.Is.is;
@@ -49,7 +52,7 @@ public abstract class BaseSearchSerialPublicationByQueryHandlerTest extends Sear
         var issn = randomIssn();
         var testChannel = new TestChannel(year, UUID.randomUUID().toString(), type).withPrintIssn(issn);
         var input = constructRequest(Map.of("year", year, "query", issn), mediaType);
-        var expectedSearchResult = mockChannelFoundAndReturnExpectedResponse(year, issn, testChannel);
+        var expectedSearchResult = mockChannelFoundAndReturnExpectedResponse(year, ISSN_QUERY_PARAM, issn, testChannel);
         var expectedMediaType =
             mediaType.equals(MediaType.ANY_TYPE) ? MediaType.JSON_UTF_8.toString() : mediaType.toString();
 
@@ -98,12 +101,38 @@ public abstract class BaseSearchSerialPublicationByQueryHandlerTest extends Sear
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
     }
 
+    @Test
+    void shouldReturnResultWithSuccessWhenQueryIsName() throws IOException, UnprocessableContentException {
+        var year = randomYear();
+        var name = randomString();
+        var expectedSearchResult = getExpectedPaginatedSearchResultNameSearch(year, name);
+        var input = constructRequest(Map.of("year", year, "query", name), MediaType.ANY_TYPE);
+
+        handlerUnderTest.handleRequest(input, output, context);
+
+        var response = GatewayResponse.fromOutputStream(output, PaginatedSearchResult.class);
+        var pagesSearchResult = objectMapper.readValue(response.getBody(), TYPE_REF);
+
+        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
+        assertThat(pagesSearchResult.getTotalHits(), is(equalTo(expectedSearchResult.getHits().size())));
+
+        assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
+    }
+
+    private PaginatedSearchResult<SerialPublicationDto> getExpectedPaginatedSearchResultNameSearch(String year,
+                                                                                                   String name)
+        throws UnprocessableContentException {
+        var pid = UUID.randomUUID().toString();
+        var testChannel = new TestChannel(year, pid, type).withName(name);
+        return mockChannelFoundAndReturnExpectedResponse(year, NAME_QUERY_PARAM, name, testChannel);
+    }
+
     private PaginatedSearchResult<SerialPublicationDto> getExpectedPaginatedSearchResultIssnSearch(
         String year, String printIssn)
         throws UnprocessableContentException {
         var pid = UUID.randomUUID().toString();
         var testChannel = new TestChannel(year, pid, type).withPrintIssn(printIssn);
-        return mockChannelFoundAndReturnExpectedResponse(year, printIssn, testChannel);
+        return mockChannelFoundAndReturnExpectedResponse(year, ISSN_QUERY_PARAM, printIssn, testChannel);
     }
 
     private PaginatedSearchResult<SerialPublicationDto> getExpectedPaginatedSearchResultIssnSearchThirdPartyDoesNotProvideYear(
@@ -111,21 +140,25 @@ public abstract class BaseSearchSerialPublicationByQueryHandlerTest extends Sear
         throws UnprocessableContentException {
         var pid = UUID.randomUUID().toString();
         var testChannel = new TestChannel(null, pid, type).withPrintIssn(printIssn);
-        return mockChannelFoundAndReturnExpectedResponse(year, printIssn, testChannel);
+        return mockChannelFoundAndReturnExpectedResponse(year, ISSN_QUERY_PARAM, printIssn, testChannel);
     }
 
-    private PaginatedSearchResult<SerialPublicationDto> mockChannelFoundAndReturnExpectedResponse(String year,
-                                                                                                  String issn,
-                                                                                                  TestChannel testChannel)
-        throws UnprocessableContentException {
+    private PaginatedSearchResult<SerialPublicationDto> mockChannelFoundAndReturnExpectedResponse(
+        String year,
+        String queryParamValue,
+        String queryParamKey,
+        TestChannel testChannel) throws UnprocessableContentException {
         var expectedParams = new HashMap<String, String>();
-        expectedParams.put("query", issn);
+        expectedParams.put("query", queryParamValue);
         if (nonNull(year)) {
             expectedParams.put("year", year);
         }
 
         var expectedHits = List.of(testChannel.asSerialPublicationDto(selfBaseUri, year));
-        mockChannelRegistryResponse(year, issn, List.of(testChannel.asChannelRegistrySerialPublicationBody()));
+        mockChannelRegistryResponse(year,
+                                    queryParamKey,
+                                    queryParamValue,
+                                    List.of(testChannel.asChannelRegistrySerialPublicationBody()));
 
         return PaginatedSearchResult.create(constructPublicationChannelUri(testChannel.type(), expectedParams),
                                             DEFAULT_OFFSET_INT,

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/BaseSearchSerialPublicationByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/BaseSearchSerialPublicationByQueryHandlerTest.java
@@ -29,6 +29,7 @@ import no.unit.nva.commons.pagination.PaginatedSearchResult;
 import no.unit.nva.stubs.FakeContext;
 import nva.commons.apigateway.GatewayResponse;
 import nva.commons.apigateway.exceptions.UnprocessableContentException;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -47,33 +48,58 @@ public abstract class BaseSearchSerialPublicationByQueryHandlerTest extends Sear
         var year = randomYear();
         var issn = randomIssn();
         var testChannel = new TestChannel(year, UUID.randomUUID().toString(), type).withPrintIssn(issn);
-        mockChannelRegistryResponse(year, issn, List.of(testChannel.asChannelRegistrySerialPublicationBody()));
         var input = constructRequest(Map.of("year", year, "query", issn), mediaType);
+        var expectedSearchResult = mockChannelFoundAndReturnExpectedResponse(year, issn, testChannel);
+        var expectedMediaType =
+            mediaType.equals(MediaType.ANY_TYPE) ? MediaType.JSON_UTF_8.toString() : mediaType.toString();
 
         this.handlerUnderTest.handleRequest(input, output, context);
         var response = GatewayResponse.fromOutputStream(output, PaginatedSearchResult.class);
         var pagesSearchResult = objectMapper.readValue(response.getBody(), TYPE_REF);
         var contentType = response.getHeaders().get(CONTENT_TYPE);
 
-        var expectedMediaType =
-            mediaType.equals(MediaType.ANY_TYPE) ? MediaType.JSON_UTF_8.toString() : mediaType.toString();
-        var expectedSearchResult = getExpectedSearchResult(year, issn, testChannel);
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
         assertThat(contentType, is(equalTo(expectedMediaType)));
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
     }
 
-    private PaginatedSearchResult<SerialPublicationDto> getExpectedSearchResult(String year,
-                                                                                String printIssn,
-                                                                                TestChannel testChannel)
+    @Test
+    void shouldReturnResultWithSuccessWhenQueryIsIssn() throws IOException, UnprocessableContentException {
+        var year = randomYear();
+        var issn = randomIssn();
+        var expectedSearchResult = getExpectedPaginatedSearchResultIssnSearch(year, issn);
+
+        var input = constructRequest(Map.of("year", year, "query", issn), MediaType.ANY_TYPE);
+
+        this.handlerUnderTest.handleRequest(input, output, context);
+
+        var response = GatewayResponse.fromOutputStream(output, PaginatedSearchResult.class);
+        var pagesSearchResult = objectMapper.readValue(response.getBody(), TYPE_REF);
+
+        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
+        assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
+    }
+
+    private PaginatedSearchResult<SerialPublicationDto> getExpectedPaginatedSearchResultIssnSearch(
+        String year, String printIssn)
+        throws UnprocessableContentException {
+        var pid = UUID.randomUUID().toString();
+        var testChannel = new TestChannel(year, pid, type).withPrintIssn(printIssn);
+        return mockChannelFoundAndReturnExpectedResponse(year, printIssn, testChannel);
+    }
+
+    private PaginatedSearchResult<SerialPublicationDto> mockChannelFoundAndReturnExpectedResponse(String year,
+                                                                                                  String issn,
+                                                                                                  TestChannel testChannel)
         throws UnprocessableContentException {
         var expectedParams = new HashMap<String, String>();
-        expectedParams.put("query", printIssn);
+        expectedParams.put("query", issn);
         if (nonNull(year)) {
             expectedParams.put("year", year);
         }
 
         var expectedHits = List.of(testChannel.asSerialPublicationDto(selfBaseUri, year));
+        mockChannelRegistryResponse(year, issn, List.of(testChannel.asChannelRegistrySerialPublicationBody()));
 
         return PaginatedSearchResult.create(constructPublicationChannelUri(testChannel.type(), expectedParams),
                                             DEFAULT_OFFSET_INT,

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/SearchByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/SearchByQueryHandlerTest.java
@@ -58,17 +58,15 @@ public abstract class SearchByQueryHandlerTest {
     protected SearchByQueryHandler<?> handlerUnderTest;
     protected final ByteArrayOutputStream output = new ByteArrayOutputStream();
     protected static Environment environment;
+    protected String customChannelPath;
     protected ChannelRegistryClient publicationChannelClient;
-
-    // TODO: Make field
-    protected abstract String getPath();
 
     protected void stubChannelRegistrySearchResponse(String body, int status, String... queryValue) {
         if (queryValue.length % 2 != 0) {
             throw new RuntimeException();
         }
         var queryParams = getStringStringValuePatternHashMap(queryValue);
-        var url = getChannelRegistryRequestUrl(getPath(), queryValue);
+        var url = getChannelRegistryRequestUrl(customChannelPath, queryValue);
 
         stubFor(get(url.toString()).withHeader("Accept", WireMock.equalTo("application/json"))
                                    .withQueryParams(queryParams)

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/SearchByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/SearchByQueryHandlerTest.java
@@ -60,6 +60,7 @@ public abstract class SearchByQueryHandlerTest {
     protected static Environment environment;
     protected ChannelRegistryClient publicationChannelClient;
 
+    // TODO: Make field
     protected abstract String getPath();
 
     protected void stubChannelRegistrySearchResponse(String body, int status, String... queryValue) {

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/SearchByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/SearchByQueryHandlerTest.java
@@ -9,7 +9,9 @@ import static no.sikt.nva.pubchannels.TestConstants.CHANNEL_REGISTRY_PAGE_COUNT_
 import static no.sikt.nva.pubchannels.TestConstants.CHANNEL_REGISTRY_PAGE_NO_PARAM;
 import static no.sikt.nva.pubchannels.TestConstants.CUSTOM_DOMAIN_BASE_PATH;
 import static no.sikt.nva.pubchannels.TestConstants.DEFAULT_OFFSET;
+import static no.sikt.nva.pubchannels.TestConstants.DEFAULT_OFFSET_INT;
 import static no.sikt.nva.pubchannels.TestConstants.DEFAULT_SIZE;
+import static no.sikt.nva.pubchannels.TestConstants.DEFAULT_SIZE_INT;
 import static no.sikt.nva.pubchannels.TestConstants.NAME_QUERY_PARAM;
 import static no.sikt.nva.pubchannels.TestConstants.TOO_LONG_INPUT_STRING;
 import static no.sikt.nva.pubchannels.TestConstants.WILD_CARD;
@@ -75,11 +77,25 @@ public abstract class SearchByQueryHandlerTest {
     }
 
     protected void mockChannelRegistryResponse(String year,
-                                               String queryParamValue,
                                                String queryParamKey,
+                                               String queryParamValue,
                                                List<String> channelRegistryEntityResult
                                               ) {
-        var responseBody = getChannelRegistrySearchResponseBody(channelRegistryEntityResult, 0, 10);
+        mockChannelRegistryResponse(year, queryParamKey, queryParamValue, channelRegistryEntityResult, DEFAULT_SIZE_INT,
+                                    DEFAULT_OFFSET_INT);
+    }
+
+    protected void mockChannelRegistryResponse(String year,
+                                               String queryParamKey,
+                                               String queryParamValue,
+                                               List<String> channelRegistryEntityResult,
+                                               int size,
+                                               int offset
+                                              ) {
+
+        var responseBody = getChannelRegistrySearchResponseBody(channelRegistryEntityResult, offset,
+                                                                size);
+        var pageNumber = size == 0 ? "0" : String.valueOf(offset / size);
         stubChannelRegistrySearchResponse(responseBody,
                                           HttpURLConnection.HTTP_OK,
                                           YEAR_QUERY_PARAM,
@@ -87,9 +103,9 @@ public abstract class SearchByQueryHandlerTest {
                                           queryParamKey,
                                           queryParamValue,
                                           CHANNEL_REGISTRY_PAGE_COUNT_PARAM,
-                                          DEFAULT_SIZE,
+                                          String.valueOf(size),
                                           CHANNEL_REGISTRY_PAGE_NO_PARAM,
-                                          DEFAULT_OFFSET);
+                                          pageNumber);
     }
 
     @BeforeAll

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/SearchByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/SearchByQueryHandlerTest.java
@@ -55,7 +55,7 @@ import org.zalando.problem.Problem;
 @WireMockTest(httpsEnabled = true)
 public abstract class SearchByQueryHandlerTest {
 
-    private static final Context context = new FakeContext();
+    protected static final Context context = new FakeContext();
     protected SearchByQueryHandler<?> handlerUnderTest;
     protected final ByteArrayOutputStream output = new ByteArrayOutputStream();
     protected static Environment environment;

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/SearchByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/SearchByQueryHandlerTest.java
@@ -181,14 +181,14 @@ public abstract class SearchByQueryHandlerTest {
         stubChannelRegistrySearchResponse(responseBody,
                                           HttpURLConnection.HTTP_INTERNAL_ERROR,
                                           YEAR_QUERY_PARAM,
-                                          String.valueOf(year),
+                                          year,
                                           CHANNEL_REGISTRY_PAGE_COUNT_PARAM,
                                           DEFAULT_SIZE,
                                           CHANNEL_REGISTRY_PAGE_NO_PARAM,
                                           DEFAULT_OFFSET,
                                           NAME_QUERY_PARAM,
                                           name);
-        var input = constructRequest(Map.of("year", String.valueOf(year), "query", name), MediaType.ANY_TYPE);
+        var input = constructRequest(Map.of("year", year, "query", name), MediaType.ANY_TYPE);
 
         handlerUnderTest.handleRequest(input, output, context);
         var response = GatewayResponse.fromOutputStream(output, Problem.class);

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/SearchByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/SearchByQueryHandlerTest.java
@@ -3,19 +3,18 @@ package no.sikt.nva.pubchannels.handler.search;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static no.sikt.nva.pubchannels.TestConstants.API_DOMAIN;
 import static no.sikt.nva.pubchannels.TestConstants.CHANNEL_REGISTRY_PAGE_COUNT_PARAM;
 import static no.sikt.nva.pubchannels.TestConstants.CHANNEL_REGISTRY_PAGE_NO_PARAM;
 import static no.sikt.nva.pubchannels.TestConstants.CUSTOM_DOMAIN_BASE_PATH;
 import static no.sikt.nva.pubchannels.TestConstants.DEFAULT_OFFSET;
 import static no.sikt.nva.pubchannels.TestConstants.DEFAULT_SIZE;
-import static no.sikt.nva.pubchannels.TestConstants.ISSN_QUERY_PARAM;
 import static no.sikt.nva.pubchannels.TestConstants.NAME_QUERY_PARAM;
 import static no.sikt.nva.pubchannels.TestConstants.TOO_LONG_INPUT_STRING;
 import static no.sikt.nva.pubchannels.TestConstants.WILD_CARD;
 import static no.sikt.nva.pubchannels.TestConstants.YEAR_QUERY_PARAM;
 import static no.sikt.nva.pubchannels.handler.TestUtils.constructRequest;
-import static no.sikt.nva.pubchannels.handler.TestUtils.getChannelRegistryRequestUrl;
 import static no.sikt.nva.pubchannels.handler.TestUtils.getChannelRegistrySearchResponseBody;
 import static no.sikt.nva.pubchannels.handler.TestUtils.getChannelRegistrySearchResult;
 import static no.sikt.nva.pubchannels.handler.TestUtils.getStringStringValuePatternHashMap;
@@ -66,25 +65,27 @@ public abstract class SearchByQueryHandlerTest {
             throw new RuntimeException();
         }
         var queryParams = getStringStringValuePatternHashMap(queryValue);
-        var url = getChannelRegistryRequestUrl(customChannelPath, queryValue);
 
-        stubFor(get(url.toString()).withHeader("Accept", WireMock.equalTo("application/json"))
-                                   .withQueryParams(queryParams)
-                                   .willReturn(aResponse().withStatus(status)
+        var testUrl = "/" + customChannelPath + "/channels";
+        stubFor(get(urlPathEqualTo(testUrl)).withHeader("Accept", WireMock.equalTo("application/json"))
+                                            .withQueryParams(queryParams)
+                                            .willReturn(aResponse().withStatus(status)
                                                           .withHeader("Content-Type", "application/json;charset=UTF-8")
                                                           .withBody(body)));
     }
 
     protected void mockChannelRegistryResponse(String year,
-                                               String printIssn,
-                                               List<String> channelRegistryEntityResult) {
+                                               String queryParamValue,
+                                               String queryParamKey,
+                                               List<String> channelRegistryEntityResult
+                                              ) {
         var responseBody = getChannelRegistrySearchResponseBody(channelRegistryEntityResult, 0, 10);
         stubChannelRegistrySearchResponse(responseBody,
                                           HttpURLConnection.HTTP_OK,
-                                          ISSN_QUERY_PARAM,
-                                          printIssn,
                                           YEAR_QUERY_PARAM,
                                           year,
+                                          queryParamKey,
+                                          queryParamValue,
                                           CHANNEL_REGISTRY_PAGE_COUNT_PARAM,
                                           DEFAULT_SIZE,
                                           CHANNEL_REGISTRY_PAGE_NO_PARAM,

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/journal/SearchJournalByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/journal/SearchJournalByQueryHandlerTest.java
@@ -69,23 +69,6 @@ class SearchJournalByQueryHandlerTest extends BaseSearchSerialPublicationByQuery
     }
 
     @Test
-    void shouldReturnResultWithSuccessWhenQueryIsIssn() throws IOException, UnprocessableContentException {
-        var year = randomYear();
-        var issn = randomIssn();
-        var expectedSearchResult = getExpectedPaginatedSearchResultIssnSearch(year, issn);
-
-        var input = constructRequest(Map.of("year", year, "query", issn), MediaType.ANY_TYPE);
-
-        this.handlerUnderTest.handleRequest(input, output, context);
-
-        var response = GatewayResponse.fromOutputStream(output, PaginatedSearchResult.class);
-        var pagesSearchResult = objectMapper.readValue(response.getBody(), TYPE_REF);
-
-        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
-        assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
-    }
-
-    @Test
     void shouldReturnResultWithRequestedYearIfThirdPartyDoesNotProvideYear()
         throws IOException, UnprocessableContentException {
         var year = randomYear();
@@ -297,19 +280,6 @@ class SearchJournalByQueryHandlerTest extends BaseSearchSerialPublicationByQuery
                                             DEFAULT_SIZE_INT,
                                             expectedHits.size(),
                                             expectedHits);
-    }
-
-    private PaginatedSearchResult<SerialPublicationDto> getExpectedPaginatedSearchResultIssnSearch(String year,
-                                                                                                   String printIssn)
-        throws UnprocessableContentException {
-        var pid = UUID.randomUUID().toString();
-        var testChannel = new TestChannel(year, pid, "Journal").withPrintIssn(printIssn);
-
-        mockChannelRegistryResponse(String.valueOf(year),
-                                    printIssn,
-                                    List.of(testChannel.asChannelRegistrySerialPublicationBody()));
-
-        return getExpectedSearchResult(year, printIssn, testChannel);
     }
 
     private PaginatedSearchResult<SerialPublicationDto> getExpectedPaginatedSearchResultIssnSearchThirdPartyDoesNotProvideYear(

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/journal/SearchJournalByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/journal/SearchJournalByQueryHandlerTest.java
@@ -57,15 +57,11 @@ class SearchJournalByQueryHandlerTest extends BaseSearchSerialPublicationByQuery
     private static final TypeReference<PaginatedSearchResult<SerialPublicationDto>> TYPE_REF = new TypeReference<>() {
     };
 
-    @Override
-    protected String getPath() {
-        return ChannelType.JOURNAL.pathElement;
-    }
-
     @BeforeEach
     void setup() {
         this.handlerUnderTest = new SearchJournalByQueryHandler(environment, publicationChannelClient);
         this.type = JOURNAL_TYPE;
+        this.customChannelPath = ChannelType.JOURNAL.pathElement;
         this.selfBaseUri = UriWrapper.fromHost(API_DOMAIN)
                                      .addChild(CUSTOM_DOMAIN_BASE_PATH)
                                      .addChild(JOURNAL_PATH)

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/journal/SearchJournalByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/journal/SearchJournalByQueryHandlerTest.java
@@ -63,40 +63,6 @@ class SearchJournalByQueryHandlerTest extends BaseSearchSerialPublicationByQuery
     }
 
     @Test
-    void shouldReturnResultWithSuccessWhenQueryIsName() throws IOException, UnprocessableContentException {
-        var year = randomYear();
-        var name = randomString();
-        int maxNr = 30;
-        int offset = 0;
-        int size = 10;
-        var channelRegistrySearchResult = getChannelRegistrySearchResult(year, name, maxNr);
-        var responseBody = getChannelRegistrySearchResponseBody(channelRegistrySearchResult, offset, size);
-        stubChannelRegistrySearchResponse(responseBody,
-                                          HttpURLConnection.HTTP_OK,
-                                          YEAR_QUERY_PARAM,
-                                          year,
-                                          CHANNEL_REGISTRY_PAGE_COUNT_PARAM,
-                                          DEFAULT_SIZE,
-                                          CHANNEL_REGISTRY_PAGE_NO_PARAM,
-                                          DEFAULT_OFFSET,
-                                          NAME_QUERY_PARAM,
-                                          name);
-        var input = constructRequest(Map.of("year", year, "query", name), MediaType.ANY_TYPE);
-
-        handlerUnderTest.handleRequest(input, output, context);
-
-        var response = GatewayResponse.fromOutputStream(output, PaginatedSearchResult.class);
-        var pagesSearchResult = objectMapper.readValue(response.getBody(),
-                                                       TYPE_REF);
-
-        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
-        assertThat(pagesSearchResult.getTotalHits(), is(equalTo(channelRegistrySearchResult.size())));
-        var expectedSearchResult = getExpectedPaginatedSearchJournalResultNameSearch(
-            channelRegistrySearchResult, year, name, offset, size);
-        assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
-    }
-
-    @Test
     void shouldReturnResultWithSuccessWhenQueryOmitsYear() throws IOException, UnprocessableContentException {
         var year = randomYear();
         var name = randomString();

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/journal/SearchJournalByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/journal/SearchJournalByQueryHandlerTest.java
@@ -1,52 +1,15 @@
 package no.sikt.nva.pubchannels.handler.search.journal;
 
 import static no.sikt.nva.pubchannels.TestConstants.API_DOMAIN;
-import static no.sikt.nva.pubchannels.TestConstants.CHANNEL_REGISTRY_PAGE_COUNT_PARAM;
-import static no.sikt.nva.pubchannels.TestConstants.CHANNEL_REGISTRY_PAGE_NO_PARAM;
 import static no.sikt.nva.pubchannels.TestConstants.CUSTOM_DOMAIN_BASE_PATH;
-import static no.sikt.nva.pubchannels.TestConstants.DEFAULT_OFFSET;
-import static no.sikt.nva.pubchannels.TestConstants.DEFAULT_SIZE;
 import static no.sikt.nva.pubchannels.TestConstants.JOURNAL_PATH;
 import static no.sikt.nva.pubchannels.TestConstants.JOURNAL_TYPE;
-import static no.sikt.nva.pubchannels.TestConstants.NAME_QUERY_PARAM;
-import static no.sikt.nva.pubchannels.handler.TestUtils.constructPublicationChannelUri;
-import static no.sikt.nva.pubchannels.handler.TestUtils.constructRequest;
-import static no.sikt.nva.pubchannels.handler.TestUtils.getChannelRegistrySearchResponseBody;
-import static no.sikt.nva.pubchannels.handler.TestUtils.getChannelRegistrySearchResult;
-import static no.sikt.nva.pubchannels.handler.TestUtils.randomYear;
-import static no.unit.nva.testutils.RandomDataGenerator.objectMapper;
-import static no.unit.nva.testutils.RandomDataGenerator.randomString;
-import static nva.commons.core.attempt.Try.attempt;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsEqual.equalTo;
-import com.amazonaws.services.lambda.runtime.Context;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.google.common.net.MediaType;
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import no.sikt.nva.pubchannels.channelregistry.ChannelType;
-import no.sikt.nva.pubchannels.channelregistry.model.ChannelRegistrySerialPublication;
-import no.sikt.nva.pubchannels.handler.ThirdPartySerialPublication;
-import no.sikt.nva.pubchannels.handler.model.SerialPublicationDto;
 import no.sikt.nva.pubchannels.handler.search.BaseSearchSerialPublicationByQueryHandlerTest;
-import no.unit.nva.commons.pagination.PaginatedSearchResult;
-import no.unit.nva.stubs.FakeContext;
-import nva.commons.apigateway.GatewayResponse;
-import nva.commons.apigateway.exceptions.UnprocessableContentException;
 import nva.commons.core.paths.UriWrapper;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 class SearchJournalByQueryHandlerTest extends BaseSearchSerialPublicationByQueryHandlerTest {
-
-    private static final Context context = new FakeContext();
-    private static final TypeReference<PaginatedSearchResult<SerialPublicationDto>> TYPE_REF = new TypeReference<>() {
-    };
 
     @BeforeEach
     void setup() {
@@ -57,70 +20,5 @@ class SearchJournalByQueryHandlerTest extends BaseSearchSerialPublicationByQuery
                                      .addChild(CUSTOM_DOMAIN_BASE_PATH)
                                      .addChild(JOURNAL_PATH)
                                      .getUri();
-    }
-
-    @Test
-    void shouldReturnResultWithSuccessWhenQueryOmitsYear() throws IOException, UnprocessableContentException {
-        var year = randomYear();
-        var name = randomString();
-        int maxNr = 30;
-        int offset = 0;
-        int size = 10;
-        var result = getChannelRegistrySearchResult(year, name, maxNr);
-        var responseBody = getChannelRegistrySearchResponseBody(result, offset, size);
-        stubChannelRegistrySearchResponse(responseBody,
-                                          HttpURLConnection.HTTP_OK,
-                                          CHANNEL_REGISTRY_PAGE_COUNT_PARAM,
-                                          DEFAULT_SIZE,
-                                          CHANNEL_REGISTRY_PAGE_NO_PARAM,
-                                          DEFAULT_OFFSET,
-                                          NAME_QUERY_PARAM,
-                                          name);
-        var input = constructRequest(Map.of("query", name), MediaType.ANY_TYPE);
-
-        handlerUnderTest.handleRequest(input, output, context);
-
-        var response = GatewayResponse.fromOutputStream(output, PaginatedSearchResult.class);
-        var pagesSearchResult = objectMapper.readValue(response.getBody(), TYPE_REF);
-
-        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
-        assertThat(pagesSearchResult.getTotalHits(), is(equalTo(result.size())));
-        var expectedSearchResult = getExpectedPaginatedSearchJournalResultNameSearch(result, null, name, offset, size);
-        assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
-    }
-
-    private static PaginatedSearchResult<SerialPublicationDto> getExpectedPaginatedSearchJournalResultNameSearch(
-        List<String> channelRegistryResults,
-        String year,
-        String name,
-        int queryOffset,
-        int querySize)
-        throws UnprocessableContentException {
-        var expectedHits = mapToJournalResults(channelRegistryResults, year);
-        var expectedParams = new HashMap<String, String>();
-        expectedParams.put("query", name);
-        if (year != null) {
-            expectedParams.put("year", year);
-        }
-
-        return PaginatedSearchResult.create(constructPublicationChannelUri(JOURNAL_PATH, null),
-                                            queryOffset,
-                                            querySize,
-                                            expectedHits.size(),
-                                            expectedHits.stream().skip(queryOffset).limit(querySize).toList(),
-                                            expectedParams);
-    }
-
-    private static List<SerialPublicationDto> mapToJournalResults(List<String> channelRegistryResults,
-                                                                  String requestedYear) {
-        return channelRegistryResults.stream()
-                   .map(result -> attempt(() -> objectMapper.readValue(result,
-                                                                       ChannelRegistrySerialPublication.class)).orElseThrow())
-                   .map(journal -> toJournalResult(journal, requestedYear))
-                   .toList();
-    }
-
-    private static SerialPublicationDto toJournalResult(ThirdPartySerialPublication journal, String requestedYear) {
-        return SerialPublicationDto.create(constructPublicationChannelUri(JOURNAL_PATH, null), journal, requestedYear);
     }
 }

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/publisher/SearchPublisherByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/publisher/SearchPublisherByQueryHandlerTest.java
@@ -325,12 +325,12 @@ class SearchPublisherByQueryHandlerTest extends SearchByQueryHandlerTest {
         var testChannel = new TestChannel(null, pid, PublisherDto.TYPE).withPrintIssn(printIssn);
 
         var result = List.of(testChannel.asChannelRegistryPublisherBody());
-        mockChannelRegistryResponse(String.valueOf(year), ISSN_QUERY_PARAM, printIssn, result);
+        mockChannelRegistryResponse(year, ISSN_QUERY_PARAM, printIssn, result);
         var expectedParams = new HashMap<String, String>();
         expectedParams.put("query", printIssn);
-        expectedParams.put("year", String.valueOf(year));
+        expectedParams.put("year", year);
 
-        return getSingleHit(testChannel.asPublisherDto(SELF_URI_BASE, String.valueOf(year)), expectedParams);
+        return getSingleHit(testChannel.asPublisherDto(SELF_URI_BASE, year), expectedParams);
     }
 
     private PaginatedSearchResult<PublisherDto> getSingleHit(PublisherDto publisherDto,

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/publisher/SearchPublisherByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/publisher/SearchPublisherByQueryHandlerTest.java
@@ -9,6 +9,7 @@ import static no.sikt.nva.pubchannels.TestConstants.DEFAULT_OFFSET;
 import static no.sikt.nva.pubchannels.TestConstants.DEFAULT_OFFSET_INT;
 import static no.sikt.nva.pubchannels.TestConstants.DEFAULT_SIZE;
 import static no.sikt.nva.pubchannels.TestConstants.DEFAULT_SIZE_INT;
+import static no.sikt.nva.pubchannels.TestConstants.ISSN_QUERY_PARAM;
 import static no.sikt.nva.pubchannels.TestConstants.NAME_QUERY_PARAM;
 import static no.sikt.nva.pubchannels.TestConstants.PUBLISHER_PATH;
 import static no.sikt.nva.pubchannels.TestConstants.YEAR_QUERY_PARAM;
@@ -308,7 +309,7 @@ class SearchPublisherByQueryHandlerTest extends SearchByQueryHandlerTest {
         var testChannel = new TestChannel(year, pid, PublisherDto.TYPE).withPrintIssn(printIssn);
 
         var result = List.of(testChannel.asChannelRegistryPublisherBody());
-        mockChannelRegistryResponse(String.valueOf(year), printIssn, result);
+        mockChannelRegistryResponse(String.valueOf(year), ISSN_QUERY_PARAM, printIssn, result);
         var expectedParams = new HashMap<String, String>();
         expectedParams.put("query", printIssn);
         expectedParams.put("year", String.valueOf(year));
@@ -324,7 +325,7 @@ class SearchPublisherByQueryHandlerTest extends SearchByQueryHandlerTest {
         var testChannel = new TestChannel(null, pid, PublisherDto.TYPE).withPrintIssn(printIssn);
 
         var result = List.of(testChannel.asChannelRegistryPublisherBody());
-        mockChannelRegistryResponse(String.valueOf(year), printIssn, result);
+        mockChannelRegistryResponse(String.valueOf(year), ISSN_QUERY_PARAM, printIssn, result);
         var expectedParams = new HashMap<String, String>();
         expectedParams.put("query", printIssn);
         expectedParams.put("year", String.valueOf(year));

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/publisher/SearchPublisherByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/publisher/SearchPublisherByQueryHandlerTest.java
@@ -63,14 +63,10 @@ class SearchPublisherByQueryHandlerTest extends SearchByQueryHandlerTest {
     private static final TypeReference<PaginatedSearchResult<PublisherDto>> TYPE_REF = new TypeReference<>() {
     };
 
-    @Override
-    protected String getPath() {
-        return ChannelType.PUBLISHER.pathElement;
-    }
-
     @BeforeEach
     void setup() {
         this.handlerUnderTest = new SearchPublisherByQueryHandler(environment, publicationChannelClient);
+        this.customChannelPath = ChannelType.PUBLISHER.pathElement;
     }
 
     @ParameterizedTest(name = "Should return requested media type \"{0}\"")

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/publisher/SearchPublisherByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/publisher/SearchPublisherByQueryHandlerTest.java
@@ -1,8 +1,10 @@
 package no.sikt.nva.pubchannels.handler.search.publisher;
 
 import static no.sikt.nva.pubchannels.HttpHeaders.CONTENT_TYPE;
+import static no.sikt.nva.pubchannels.TestConstants.API_DOMAIN;
 import static no.sikt.nva.pubchannels.TestConstants.CHANNEL_REGISTRY_PAGE_COUNT_PARAM;
 import static no.sikt.nva.pubchannels.TestConstants.CHANNEL_REGISTRY_PAGE_NO_PARAM;
+import static no.sikt.nva.pubchannels.TestConstants.CUSTOM_DOMAIN_BASE_PATH;
 import static no.sikt.nva.pubchannels.TestConstants.DEFAULT_OFFSET;
 import static no.sikt.nva.pubchannels.TestConstants.DEFAULT_OFFSET_INT;
 import static no.sikt.nva.pubchannels.TestConstants.DEFAULT_SIZE;
@@ -44,6 +46,7 @@ import no.unit.nva.commons.pagination.PaginatedSearchResult;
 import no.unit.nva.stubs.FakeContext;
 import nva.commons.apigateway.GatewayResponse;
 import nva.commons.apigateway.exceptions.UnprocessableContentException;
+import nva.commons.core.paths.UriWrapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -51,7 +54,11 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class SearchPublisherByQueryHandlerTest extends SearchByQueryHandlerTest {
 
-    private static final String SELF_URI_BASE = "https://localhost/publication-channels/" + PUBLISHER_PATH;
+    private static final String SELF_URI_BASE = UriWrapper.fromHost(API_DOMAIN)
+                                                          .addChild(CUSTOM_DOMAIN_BASE_PATH)
+                                                          .addChild(PUBLISHER_PATH)
+                                                          .getUri()
+                                                          .toString();
     private static final Context context = new FakeContext();
     private static final TypeReference<PaginatedSearchResult<PublisherDto>> TYPE_REF = new TypeReference<>() {
     };

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/publisher/SearchPublisherByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/publisher/SearchPublisherByQueryHandlerTest.java
@@ -97,7 +97,7 @@ class SearchPublisherByQueryHandlerTest extends SearchByQueryHandlerTest {
         var issn = randomIssn();
         var expectedSearchResult = getExpectedPaginatedSearchResultIssnSearch(year, issn);
 
-        var input = constructRequest(Map.of("year", String.valueOf(year), "query", issn), MediaType.ANY_TYPE);
+        var input = constructRequest(Map.of("year", year, "query", issn), MediaType.ANY_TYPE);
 
         this.handlerUnderTest.handleRequest(input, output, context);
 

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/serialpublication/SearchSerialPublicationByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/serialpublication/SearchSerialPublicationByQueryHandlerTest.java
@@ -1,49 +1,15 @@
 package no.sikt.nva.pubchannels.handler.search.serialpublication;
 
-import static java.util.Objects.nonNull;
-import static no.sikt.nva.pubchannels.HttpHeaders.CONTENT_TYPE;
-import static no.sikt.nva.pubchannels.TestConstants.DEFAULT_OFFSET_INT;
-import static no.sikt.nva.pubchannels.TestConstants.DEFAULT_SIZE_INT;
+import static no.sikt.nva.pubchannels.TestConstants.API_DOMAIN;
+import static no.sikt.nva.pubchannels.TestConstants.CUSTOM_DOMAIN_BASE_PATH;
 import static no.sikt.nva.pubchannels.TestConstants.JOURNAL_TYPE;
 import static no.sikt.nva.pubchannels.TestConstants.SERIAL_PUBLICATION_PATH;
-import static no.sikt.nva.pubchannels.handler.TestUtils.constructPublicationChannelUri;
-import static no.sikt.nva.pubchannels.handler.TestUtils.constructRequest;
-import static no.sikt.nva.pubchannels.handler.TestUtils.randomYear;
-import static no.unit.nva.testutils.RandomDataGenerator.objectMapper;
-import static no.unit.nva.testutils.RandomDataGenerator.randomIssn;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsEqual.equalTo;
-import com.amazonaws.services.lambda.runtime.Context;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.google.common.net.MediaType;
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.URI;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
 import no.sikt.nva.pubchannels.channelregistry.ChannelType;
-import no.sikt.nva.pubchannels.handler.TestChannel;
-import no.sikt.nva.pubchannels.handler.model.SerialPublicationDto;
-import no.sikt.nva.pubchannels.handler.search.SearchByQueryHandlerTest;
-import no.unit.nva.commons.pagination.PaginatedSearchResult;
-import no.unit.nva.stubs.FakeContext;
-import nva.commons.apigateway.GatewayResponse;
-import nva.commons.apigateway.exceptions.UnprocessableContentException;
+import no.sikt.nva.pubchannels.handler.search.BaseSearchSerialPublicationByQueryHandlerTest;
+import nva.commons.core.paths.UriWrapper;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 
-class SearchSerialPublicationByQueryHandlerTest extends SearchByQueryHandlerTest {
-
-    private static final Context context = new FakeContext();
-    private static final URI SELF_URI_BASE = URI.create(
-        "https://localhost/publication-channels/" + SERIAL_PUBLICATION_PATH);
-    private static final TypeReference<PaginatedSearchResult<SerialPublicationDto>> TYPE_REF = new TypeReference<>() {
-    };
+class SearchSerialPublicationByQueryHandlerTest extends BaseSearchSerialPublicationByQueryHandlerTest {
 
     @Override
     protected String getPath() {
@@ -53,47 +19,10 @@ class SearchSerialPublicationByQueryHandlerTest extends SearchByQueryHandlerTest
     @BeforeEach
     void setup() {
         this.handlerUnderTest = new SearchSerialPublicationByQueryHandler(environment, publicationChannelClient);
-    }
-
-    @ParameterizedTest(name = "Should return requested media type \"{0}\"")
-    @MethodSource("no.sikt.nva.pubchannels.handler.TestUtils#mediaTypeProvider")
-    void shouldReturnContentNegotiatedContentWhenRequested(MediaType mediaType)
-        throws IOException, UnprocessableContentException {
-        var year = randomYear();
-        var issn = randomIssn();
-        var testChannel = new TestChannel(year, UUID.randomUUID().toString(), JOURNAL_TYPE).withPrintIssn(issn);
-        mockChannelRegistryResponse(year, issn, List.of(testChannel.asChannelRegistrySerialPublicationBody()));
-        var input = constructRequest(Map.of("year", year, "query", issn), mediaType);
-
-        this.handlerUnderTest.handleRequest(input, output, context);
-        var response = GatewayResponse.fromOutputStream(output, PaginatedSearchResult.class);
-        var pagesSearchResult = objectMapper.readValue(response.getBody(), TYPE_REF);
-        var contentType = response.getHeaders().get(CONTENT_TYPE);
-
-        var expectedMediaType =
-            mediaType.equals(MediaType.ANY_TYPE) ? MediaType.JSON_UTF_8.toString() : mediaType.toString();
-        var expectedSearchResult = getExpectedSearchResult(String.valueOf(year), issn, testChannel);
-        assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
-        assertThat(contentType, is(equalTo(expectedMediaType)));
-        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
-    }
-
-    private static PaginatedSearchResult<SerialPublicationDto> getExpectedSearchResult(String year,
-                                                                                       String printIssn,
-                                                                                       TestChannel testChannel)
-        throws UnprocessableContentException {
-        var expectedParams = new HashMap<String, String>();
-        expectedParams.put("query", printIssn);
-        if (nonNull(year)) {
-            expectedParams.put("year", year);
-        }
-
-        var expectedHits = List.of(testChannel.asSerialPublicationDto(SELF_URI_BASE, year));
-
-        return PaginatedSearchResult.create(constructPublicationChannelUri(testChannel.type(), expectedParams),
-                                            DEFAULT_OFFSET_INT,
-                                            DEFAULT_SIZE_INT,
-                                            expectedHits.size(),
-                                            expectedHits);
+        this.type = JOURNAL_TYPE;
+        this.selfBaseUri = UriWrapper.fromHost(API_DOMAIN)
+                                     .addChild(CUSTOM_DOMAIN_BASE_PATH)
+                                     .addChild(SERIAL_PUBLICATION_PATH)
+                                     .getUri();
     }
 }

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/serialpublication/SearchSerialPublicationByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/serialpublication/SearchSerialPublicationByQueryHandlerTest.java
@@ -11,15 +11,11 @@ import org.junit.jupiter.api.BeforeEach;
 
 class SearchSerialPublicationByQueryHandlerTest extends BaseSearchSerialPublicationByQueryHandlerTest {
 
-    @Override
-    protected String getPath() {
-        return ChannelType.SERIAL_PUBLICATION.pathElement;
-    }
-
     @BeforeEach
     void setup() {
         this.handlerUnderTest = new SearchSerialPublicationByQueryHandler(environment, publicationChannelClient);
         this.type = JOURNAL_TYPE;
+        this.customChannelPath = ChannelType.SERIAL_PUBLICATION.pathElement;
         this.selfBaseUri = UriWrapper.fromHost(API_DOMAIN)
                                      .addChild(CUSTOM_DOMAIN_BASE_PATH)
                                      .addChild(SERIAL_PUBLICATION_PATH)

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/series/SearchSeriesByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/series/SearchSeriesByQueryHandlerTest.java
@@ -68,23 +68,6 @@ class SearchSeriesByQueryHandlerTest extends BaseSearchSerialPublicationByQueryH
     }
 
     @Test
-    void shouldReturnResultWithSuccessWhenQueryIsIssn() throws IOException, UnprocessableContentException {
-        var year = randomYear();
-        var issn = randomIssn();
-        var expectedSearchResult = getExpectedPaginatedSearchResultIssnSearch(year, issn);
-
-        var input = constructRequest(Map.of("year", year, "query", issn), MediaType.ANY_TYPE);
-
-        this.handlerUnderTest.handleRequest(input, output, context);
-
-        var response = GatewayResponse.fromOutputStream(output, PaginatedSearchResult.class);
-        var pagesSearchResult = objectMapper.readValue(response.getBody(), TYPE_REF);
-
-        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
-        assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
-    }
-
-    @Test
     void shouldReturnResultWithRequestedYearIfThirdPartyDoesNotProvideYear()
         throws IOException, UnprocessableContentException {
         var year = randomYear();
@@ -271,14 +254,6 @@ class SearchSeriesByQueryHandlerTest extends BaseSearchSerialPublicationByQueryH
 
     private static SerialPublicationDto toResult(ThirdPartySerialPublication series, String requestedYear) {
         return SerialPublicationDto.create(constructPublicationChannelUri(SERIES_PATH, null), series, requestedYear);
-    }
-
-    private PaginatedSearchResult<SerialPublicationDto> getExpectedPaginatedSearchResultIssnSearch(
-        String year, String printIssn)
-        throws UnprocessableContentException {
-        var pid = UUID.randomUUID().toString();
-        var testChannel = new TestChannel(year, pid, "Series").withPrintIssn(printIssn);
-        return createSearchResult(testChannel, String.valueOf(year), printIssn);
     }
 
     private PaginatedSearchResult<SerialPublicationDto> getExpectedPaginatedSearchResultIssnSearchThirdPartyDoesNotProvideYear(

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/series/SearchSeriesByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/series/SearchSeriesByQueryHandlerTest.java
@@ -56,15 +56,11 @@ class SearchSeriesByQueryHandlerTest extends BaseSearchSerialPublicationByQueryH
     private static final TypeReference<PaginatedSearchResult<SerialPublicationDto>> TYPE_REF = new TypeReference<>() {
     };
 
-    @Override
-    protected String getPath() {
-        return ChannelType.SERIES.pathElement;
-    }
-
     @BeforeEach
     void setup() {
         this.handlerUnderTest = new SearchSeriesByQueryHandler(environment, publicationChannelClient);
         this.type = SERIES_TYPE;
+        this.customChannelPath = ChannelType.SERIES.pathElement;
         this.selfBaseUri = UriWrapper.fromHost(API_DOMAIN)
                                      .addChild(CUSTOM_DOMAIN_BASE_PATH)
                                      .addChild(SERIES_PATH)

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/series/SearchSeriesByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/series/SearchSeriesByQueryHandlerTest.java
@@ -62,40 +62,6 @@ class SearchSeriesByQueryHandlerTest extends BaseSearchSerialPublicationByQueryH
                                      .getUri();
     }
 
-
-    @Test
-    void shouldReturnResultWithSuccessWhenQueryIsName() throws IOException, UnprocessableContentException {
-        var year = randomYear();
-        var name = randomString();
-        int maxNr = 30;
-        int offset = 0;
-        int size = 10;
-        var result = getChannelRegistrySearchResult(year, name, maxNr);
-        var responseBody = getChannelRegistrySearchResponseBody(result, offset, size);
-        stubChannelRegistrySearchResponse(responseBody,
-                                          HttpURLConnection.HTTP_OK,
-                                          YEAR_QUERY_PARAM,
-                                          year,
-                                          CHANNEL_REGISTRY_PAGE_COUNT_PARAM,
-                                          DEFAULT_SIZE,
-                                          CHANNEL_REGISTRY_PAGE_NO_PARAM,
-                                          DEFAULT_OFFSET,
-                                          NAME_QUERY_PARAM,
-                                          name);
-        var input = constructRequest(Map.of("year", year, "query", name), MediaType.ANY_TYPE);
-
-        handlerUnderTest.handleRequest(input, output, context);
-
-        var response = GatewayResponse.fromOutputStream(output, PaginatedSearchResult.class);
-        var pagesSearchResult = objectMapper.readValue(response.getBody(), TYPE_REF);
-
-        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
-        assertThat(pagesSearchResult.getTotalHits(), is(equalTo(result.size())));
-        var expectedSearchResult = getExpectedPaginatedSearchResultNameSearch(
-            result, year, name, offset, size);
-        assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
-    }
-
     @Test
     void shouldReturnResultWithSuccessWhenQueryOmitsYear() throws IOException, UnprocessableContentException {
         var year = randomYear();

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/series/SearchSeriesByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/series/SearchSeriesByQueryHandlerTest.java
@@ -9,8 +9,6 @@ import static no.sikt.nva.pubchannels.TestConstants.DEFAULT_SIZE;
 import static no.sikt.nva.pubchannels.TestConstants.NAME_QUERY_PARAM;
 import static no.sikt.nva.pubchannels.TestConstants.SERIES_PATH;
 import static no.sikt.nva.pubchannels.TestConstants.SERIES_TYPE;
-import static no.sikt.nva.pubchannels.TestConstants.YEAR_QUERY_PARAM;
-import static no.sikt.nva.pubchannels.handler.TestUtils.areEqualURIs;
 import static no.sikt.nva.pubchannels.handler.TestUtils.constructPublicationChannelUri;
 import static no.sikt.nva.pubchannels.handler.TestUtils.constructRequest;
 import static no.sikt.nva.pubchannels.handler.TestUtils.getChannelRegistrySearchResponseBody;
@@ -23,7 +21,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.net.MediaType;
@@ -90,80 +87,6 @@ class SearchSeriesByQueryHandlerTest extends BaseSearchSerialPublicationByQueryH
         assertThat(pagesSearchResult.getTotalHits(), is(equalTo(result.size())));
         var expectedSearchResult = getExpectedPaginatedSearchResultNameSearch(result, null, name, offset, size);
         assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
-    }
-
-    @Test
-    void shouldReturnResultWithSuccessWhenQueryIsNameAndOffsetIs10() throws IOException, UnprocessableContentException {
-        var year = randomYear();
-        var name = randomString();
-        int offset = 10;
-        int size = 10;
-        int maxNr = 30;
-        var result = getChannelRegistrySearchResult(year, name, maxNr);
-        stubChannelRegistrySearchResponse(
-            getChannelRegistrySearchResponseBody(result, offset, size),
-            HttpURLConnection.HTTP_OK,
-            YEAR_QUERY_PARAM, year,
-            CHANNEL_REGISTRY_PAGE_COUNT_PARAM, String.valueOf(size),
-            CHANNEL_REGISTRY_PAGE_NO_PARAM, String.valueOf(offset / size),
-            NAME_QUERY_PARAM, name);
-        var input = constructRequest(
-            Map.of("year", year, "query", name,
-                   "offset", String.valueOf(offset), "size", String.valueOf(size)), MediaType.ANY_TYPE);
-
-        handlerUnderTest.handleRequest(input, output, context);
-
-        var response = GatewayResponse.fromOutputStream(output, PaginatedSearchResult.class);
-        var pagesSearchResult = objectMapper.readValue(response.getBody(),
-                                                       TYPE_REF);
-
-        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
-        assertThat(pagesSearchResult.getTotalHits(), is(equalTo(result.size())));
-        var expectedSearchResult = getExpectedPaginatedSearchResultNameSearch(result, year, name,
-                                                                              offset, size);
-        assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
-    }
-
-    @Test
-    void shouldReturnResultWithQueryAsId() throws IOException, UnprocessableContentException {
-        var year = randomYear();
-        var name = randomString();
-        int offset = 10;
-        int size = 10;
-        int maxNr = 30;
-        var result = getChannelRegistrySearchResult(year, name, maxNr);
-        stubChannelRegistrySearchResponse(
-            getChannelRegistrySearchResponseBody(result, offset, size),
-            HttpURLConnection.HTTP_OK,
-            YEAR_QUERY_PARAM,
-            year,
-            CHANNEL_REGISTRY_PAGE_COUNT_PARAM,
-            String.valueOf(size),
-            CHANNEL_REGISTRY_PAGE_NO_PARAM,
-            String.valueOf(offset / size),
-            NAME_QUERY_PARAM,
-            name);
-        var input = constructRequest(Map.of("year",
-                                            year,
-                                            "query",
-                                            name,
-                                            "offset",
-                                            String.valueOf(offset),
-                                            "size",
-                                            String.valueOf(size)), MediaType.ANY_TYPE);
-
-        handlerUnderTest.handleRequest(input, output, context);
-
-        var response = GatewayResponse.fromOutputStream(output, PaginatedSearchResult.class);
-        var pagesSearchResult = objectMapper.readValue(response.getBody(), TYPE_REF);
-
-        var expectedSearchResult =
-            getExpectedPaginatedSearchResultNameSearch(result, year, name, offset, size);
-
-        var expectedUri = expectedSearchResult.getId();
-        var actualUri = pagesSearchResult.getId();
-
-        assertTrue(areEqualURIs(actualUri, expectedUri));
     }
 
     private static PaginatedSearchResult<SerialPublicationDto> getExpectedPaginatedSearchResultNameSearch(

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/series/SearchSeriesByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/series/SearchSeriesByQueryHandlerTest.java
@@ -5,9 +5,7 @@ import static no.sikt.nva.pubchannels.TestConstants.CHANNEL_REGISTRY_PAGE_COUNT_
 import static no.sikt.nva.pubchannels.TestConstants.CHANNEL_REGISTRY_PAGE_NO_PARAM;
 import static no.sikt.nva.pubchannels.TestConstants.CUSTOM_DOMAIN_BASE_PATH;
 import static no.sikt.nva.pubchannels.TestConstants.DEFAULT_OFFSET;
-import static no.sikt.nva.pubchannels.TestConstants.DEFAULT_OFFSET_INT;
 import static no.sikt.nva.pubchannels.TestConstants.DEFAULT_SIZE;
-import static no.sikt.nva.pubchannels.TestConstants.DEFAULT_SIZE_INT;
 import static no.sikt.nva.pubchannels.TestConstants.NAME_QUERY_PARAM;
 import static no.sikt.nva.pubchannels.TestConstants.SERIES_PATH;
 import static no.sikt.nva.pubchannels.TestConstants.SERIES_TYPE;
@@ -19,7 +17,6 @@ import static no.sikt.nva.pubchannels.handler.TestUtils.getChannelRegistrySearch
 import static no.sikt.nva.pubchannels.handler.TestUtils.getChannelRegistrySearchResult;
 import static no.sikt.nva.pubchannels.handler.TestUtils.randomYear;
 import static no.unit.nva.testutils.RandomDataGenerator.objectMapper;
-import static no.unit.nva.testutils.RandomDataGenerator.randomIssn;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static nva.commons.core.attempt.Try.attempt;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -35,10 +32,8 @@ import java.net.HttpURLConnection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import no.sikt.nva.pubchannels.channelregistry.ChannelType;
 import no.sikt.nva.pubchannels.channelregistry.model.ChannelRegistrySerialPublication;
-import no.sikt.nva.pubchannels.handler.TestChannel;
 import no.sikt.nva.pubchannels.handler.ThirdPartySerialPublication;
 import no.sikt.nva.pubchannels.handler.model.SerialPublicationDto;
 import no.sikt.nva.pubchannels.handler.search.BaseSearchSerialPublicationByQueryHandlerTest;
@@ -67,23 +62,6 @@ class SearchSeriesByQueryHandlerTest extends BaseSearchSerialPublicationByQueryH
                                      .getUri();
     }
 
-    @Test
-    void shouldReturnResultWithRequestedYearIfThirdPartyDoesNotProvideYear()
-        throws IOException, UnprocessableContentException {
-        var year = randomYear();
-        var issn = randomIssn();
-        var expectedSearchResult = getExpectedPaginatedSearchResultIssnSearchThirdPartyDoesNotProvideYear(year, issn);
-
-        var input = constructRequest(Map.of("year", year, "query", issn), MediaType.ANY_TYPE);
-
-        this.handlerUnderTest.handleRequest(input, output, context);
-
-        var response = GatewayResponse.fromOutputStream(output, PaginatedSearchResult.class);
-        var pagesSearchResult = objectMapper.readValue(response.getBody(), TYPE_REF);
-
-        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
-        assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
-    }
 
     @Test
     void shouldReturnResultWithSuccessWhenQueryIsName() throws IOException, UnprocessableContentException {
@@ -254,27 +232,5 @@ class SearchSeriesByQueryHandlerTest extends BaseSearchSerialPublicationByQueryH
 
     private static SerialPublicationDto toResult(ThirdPartySerialPublication series, String requestedYear) {
         return SerialPublicationDto.create(constructPublicationChannelUri(SERIES_PATH, null), series, requestedYear);
-    }
-
-    private PaginatedSearchResult<SerialPublicationDto> getExpectedPaginatedSearchResultIssnSearchThirdPartyDoesNotProvideYear(
-        String year, String printIssn)
-        throws UnprocessableContentException {
-        var pid = UUID.randomUUID().toString();
-        var testChannel = new TestChannel(null, pid, "Series").withPrintIssn(printIssn);
-        return createSearchResult(testChannel, String.valueOf(year), printIssn);
-    }
-
-    private PaginatedSearchResult<SerialPublicationDto> createSearchResult(TestChannel testChannel, String year,
-                                                                           String printIssn)
-        throws UnprocessableContentException {
-        mockChannelRegistryResponse(year, printIssn, List.of(testChannel.asChannelRegistrySeriesBody()));
-
-        var expectedHits = List.of(testChannel.asSerialPublicationDto(selfBaseUri, year));
-        return PaginatedSearchResult.create(constructPublicationChannelUri(SERIES_PATH,
-                                                                           Map.of("year", year, "query", printIssn)),
-                                            DEFAULT_OFFSET_INT,
-                                            DEFAULT_SIZE_INT,
-                                            expectedHits.size(),
-                                            expectedHits);
     }
 }

--- a/src/test/java/no/sikt/nva/pubchannels/handler/search/series/SearchSeriesByQueryHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/search/series/SearchSeriesByQueryHandlerTest.java
@@ -1,52 +1,15 @@
 package no.sikt.nva.pubchannels.handler.search.series;
 
 import static no.sikt.nva.pubchannels.TestConstants.API_DOMAIN;
-import static no.sikt.nva.pubchannels.TestConstants.CHANNEL_REGISTRY_PAGE_COUNT_PARAM;
-import static no.sikt.nva.pubchannels.TestConstants.CHANNEL_REGISTRY_PAGE_NO_PARAM;
 import static no.sikt.nva.pubchannels.TestConstants.CUSTOM_DOMAIN_BASE_PATH;
-import static no.sikt.nva.pubchannels.TestConstants.DEFAULT_OFFSET;
-import static no.sikt.nva.pubchannels.TestConstants.DEFAULT_SIZE;
-import static no.sikt.nva.pubchannels.TestConstants.NAME_QUERY_PARAM;
 import static no.sikt.nva.pubchannels.TestConstants.SERIES_PATH;
 import static no.sikt.nva.pubchannels.TestConstants.SERIES_TYPE;
-import static no.sikt.nva.pubchannels.handler.TestUtils.constructPublicationChannelUri;
-import static no.sikt.nva.pubchannels.handler.TestUtils.constructRequest;
-import static no.sikt.nva.pubchannels.handler.TestUtils.getChannelRegistrySearchResponseBody;
-import static no.sikt.nva.pubchannels.handler.TestUtils.getChannelRegistrySearchResult;
-import static no.sikt.nva.pubchannels.handler.TestUtils.randomYear;
-import static no.unit.nva.testutils.RandomDataGenerator.objectMapper;
-import static no.unit.nva.testutils.RandomDataGenerator.randomString;
-import static nva.commons.core.attempt.Try.attempt;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsEqual.equalTo;
-import com.amazonaws.services.lambda.runtime.Context;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.google.common.net.MediaType;
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import no.sikt.nva.pubchannels.channelregistry.ChannelType;
-import no.sikt.nva.pubchannels.channelregistry.model.ChannelRegistrySerialPublication;
-import no.sikt.nva.pubchannels.handler.ThirdPartySerialPublication;
-import no.sikt.nva.pubchannels.handler.model.SerialPublicationDto;
 import no.sikt.nva.pubchannels.handler.search.BaseSearchSerialPublicationByQueryHandlerTest;
-import no.unit.nva.commons.pagination.PaginatedSearchResult;
-import no.unit.nva.stubs.FakeContext;
-import nva.commons.apigateway.GatewayResponse;
-import nva.commons.apigateway.exceptions.UnprocessableContentException;
 import nva.commons.core.paths.UriWrapper;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 class SearchSeriesByQueryHandlerTest extends BaseSearchSerialPublicationByQueryHandlerTest {
-
-    private static final Context context = new FakeContext();
-    private static final TypeReference<PaginatedSearchResult<SerialPublicationDto>> TYPE_REF = new TypeReference<>() {
-    };
 
     @BeforeEach
     void setup() {
@@ -57,69 +20,5 @@ class SearchSeriesByQueryHandlerTest extends BaseSearchSerialPublicationByQueryH
                                      .addChild(CUSTOM_DOMAIN_BASE_PATH)
                                      .addChild(SERIES_PATH)
                                      .getUri();
-    }
-
-    @Test
-    void shouldReturnResultWithSuccessWhenQueryOmitsYear() throws IOException, UnprocessableContentException {
-        var year = randomYear();
-        var name = randomString();
-        int maxNr = 30;
-        int offset = 0;
-        int size = 10;
-        var result = getChannelRegistrySearchResult(year, name, maxNr);
-        var responseBody = getChannelRegistrySearchResponseBody(result, offset, size);
-        stubChannelRegistrySearchResponse(responseBody,
-                                          HttpURLConnection.HTTP_OK,
-                                          CHANNEL_REGISTRY_PAGE_COUNT_PARAM,
-                                          DEFAULT_SIZE,
-                                          CHANNEL_REGISTRY_PAGE_NO_PARAM,
-                                          DEFAULT_OFFSET,
-                                          NAME_QUERY_PARAM,
-                                          name);
-        var input = constructRequest(Map.of("query", name), MediaType.ANY_TYPE);
-
-        handlerUnderTest.handleRequest(input, output, context);
-
-        var response = GatewayResponse.fromOutputStream(output, PaginatedSearchResult.class);
-        var pagesSearchResult = objectMapper.readValue(response.getBody(), TYPE_REF);
-
-        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
-        assertThat(pagesSearchResult.getTotalHits(), is(equalTo(result.size())));
-        var expectedSearchResult = getExpectedPaginatedSearchResultNameSearch(result, null, name, offset, size);
-        assertThat(pagesSearchResult.getHits(), containsInAnyOrder(expectedSearchResult.getHits().toArray()));
-    }
-
-    private static PaginatedSearchResult<SerialPublicationDto> getExpectedPaginatedSearchResultNameSearch(
-        List<String> results,
-        String year,
-        String name,
-        int queryOffset,
-        int querySize)
-        throws UnprocessableContentException {
-        var expectedHits = mapToSeriesResults(results, year);
-        var expectedParams = new HashMap<String, String>();
-        expectedParams.put("query", name);
-        if (year != null) {
-            expectedParams.put("year", year);
-        }
-
-        return PaginatedSearchResult.create(constructPublicationChannelUri(SERIES_PATH, null),
-                                            queryOffset,
-                                            querySize,
-                                            expectedHits.size(),
-                                            expectedHits.stream().skip(queryOffset).limit(querySize).toList(),
-                                            expectedParams);
-    }
-
-    private static List<SerialPublicationDto> mapToSeriesResults(List<String> results, String requestedYear) {
-        return results.stream()
-                   .map(result -> attempt(() -> objectMapper.readValue(result,
-                                                                       ChannelRegistrySerialPublication.class)).orElseThrow())
-                   .map(series -> toResult(series, requestedYear))
-                   .toList();
-    }
-
-    private static SerialPublicationDto toResult(ThirdPartySerialPublication series, String requestedYear) {
-        return SerialPublicationDto.create(constructPublicationChannelUri(SERIES_PATH, null), series, requestedYear);
     }
 }


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-48010

This moves duplicate tests for search handlers to a common base test class which in turn covers the new search endpoint with the same test cases.