### PR TITLE
Np 48100 CreateSerialPublicationFunction in template and openapi spec

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -575,6 +575,7 @@ paths:
           $ref: '#/components/responses/404'
         502:
           $ref: '#/components/responses/502'
+  /serial-publication:
     post:
       x-amazon-apigateway-integration:
         uri:
@@ -582,7 +583,7 @@ paths:
         httpMethod: POST
         type: "AWS_PROXY"
       tags:
-        - Series
+        - SerialPublication
       summary: Create series/journal
       description: Returns a Location with uri for the created Series/Journal
       operationId: CreateSerialPublication

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -575,6 +575,41 @@ paths:
           $ref: '#/components/responses/404'
         502:
           $ref: '#/components/responses/502'
+    post:
+      x-amazon-apigateway-integration:
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${CreateSerialPublicationFunction.Arn}/invocations
+        httpMethod: POST
+        type: "AWS_PROXY"
+      tags:
+        - Series
+      summary: Create series/journal
+      description: Returns a Location with uri for the created Series/Journal
+      operationId: CreateSerialPublication
+      requestBody:
+        content:
+          'application/ld+json':
+            schema:
+              $ref: '#/components/schemas/CreateSerialPublication'
+            examples:
+              objectExample:
+                $ref: '#/components/examples/CreateSerialPublicationExample'
+      responses:
+        201:
+          description: successful operation
+          headers:
+            Location:
+              schema:
+                type: string
+              description: A URI to the new resource
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SerialPublication'
+        400:
+          $ref: '#/components/responses/400'
+        502:
+          $ref: '#/components/responses/502'
 
 components:
   responses:
@@ -652,6 +687,7 @@ components:
           type: string
           format: uri
           nullable: true
+      required: [ 'name' ]
     PaginatedPublishers:
       type: object
       properties:
@@ -764,6 +800,32 @@ components:
         sameAs:
           type: string
           nullable: true
+    CreateSerialPublication:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name of the series
+        type:
+          type: string
+          enum: [ 'Series', 'Journal' ]
+          description: The type of serial publication, either Series or Journal
+        printIssn:
+          type: string
+          nullable: true
+          description: The print publication ISSN
+          pattern: ^[0-9]{4}-[0-9]{3}[0-9X]$
+        onlineIssn:
+          type: string
+          nullable: true
+          description: The electronic publication ISSN
+          pattern: ^[0-9]{4}-[0-9]{3}[0-9X]$
+        homepage:
+          type: string
+          format: uri
+          nullable: true
+          description: The url to the series
+      required: [ 'name', 'type' ]
     CreateSeries:
       type: object
       properties:
@@ -785,6 +847,7 @@ components:
           format: uri
           nullable: true
           description: The url to the series
+      required: [ 'name' ]
     Context:
       type: string
       pattern: 'https:\/\/.*$'
@@ -921,6 +984,14 @@ components:
     CreateSeriesExample:
       value:
         name: 'The series of eternal fury'
+        onlineIssn: '1234-1234'
+        printIssn: '4321-4321'
+        homepage: 'https://series-of-eternal.fury.no'
+      summary: A sample create series
+    CreateSerialPublicationExample:
+      value:
+        name: 'The series of eternal fury'
+        type: 'Series'
         onlineIssn: '1234-1234'
         printIssn: '4321-4321'
         homepage: 'https://series-of-eternal.fury.no'

--- a/template.yaml
+++ b/template.yaml
@@ -379,6 +379,28 @@ Resources:
       Action: lambda:InvokeFunction
       Principal: 'apigateway.amazonaws.com'
 
+  CreateSerialPublicationFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: no.sikt.nva.pubchannels.handler.create.serialpublication.CreateSerialPublicationHandler::handleRequest
+      Policies:
+        - !GetAtt GetItemDynamoDbPolicy.PolicyArn
+        - !GetAtt ReadSecretsPolicy.PolicyArn
+      Events:
+        CreateJournalEvent:
+          Type: Api
+          Properties:
+            RestApiId: !Ref PublicationChannelsApi
+            Path: /serial-publication
+            Method: post
+
+  CreateSerialPublicationFunctionPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt CreateSerialPublicationFunction.Arn
+      Action: lambda:InvokeFunction
+      Principal: 'apigateway.amazonaws.com'
+
   SearchPublisherByQueryFunction:
     Type: AWS::Serverless::Function
     Properties:


### PR DESCRIPTION
- Add `CreateSerialPublicationFunction` in template
- Add `CreateSerialPublicationFunction` in openapi spec for `POST`
- Created separate schema `CreateSerialPublication`, because this object also requires `type`