### PR TITLE
build: Add Spotless plugin for formatting

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -17,4 +17,5 @@ dependencies {
     implementation group: 'nebula.lint', name: 'nebula.lint.gradle.plugin', version: '17.2.3'
     implementation group: 'org.jacoco', name: 'org.jacoco.core', version: '0.8.7'
     implementation group: 'org.jacoco', name: 'org.jacoco.report', version: '0.8.7'
+    implementation group: 'com.diffplug.spotless', name: 'spotless-plugin-gradle', version: '7.0.1'
 }

--- a/buildSrc/src/main/groovy/nva.publication.channels.java.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nva.publication.channels.java.java-conventions.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'checkstyle'
     id 'pmd'
     id 'jacoco-report-aggregation'
+    id 'com.diffplug.spotless'
 }
 
 group 'no.sikt.nva'
@@ -83,5 +84,19 @@ jacocoTestCoverageVerification {
                 minimum = 1.000
             }
         }
+    }
+}
+
+spotless {
+    java {
+        toggleOffOn() // Ignores sections between `spotless:off` / `spotless:on`
+        googleJavaFormat().reflowLongStrings().formatJavadoc(true).reorderImports(true)
+    }
+
+    format 'misc', {
+        target '.gitignore', '.gitattributes', '.editorconfig', '**/*.gradle'
+        indentWithSpaces(4)
+        trimTrailingWhitespace()
+        endWithNewline()
     }
 }


### PR DESCRIPTION
This adds Spotless to the project, without running the formatting task. The intention is to reformat the project later in a separate PR for easier review.