### PR TITLE
implementing update channel handler and endpoints

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,4 +14,5 @@ test {
     environment("APPLICATION_CONFIG_PROFILE_NAME", "someProfile")
     environment("APPLICATION_CONFIG_ENVIRONMENT_NAME", "someEnvironment")
     environment("APPLICATION_ID", "someId")
+    environment("COGNITO_AUTHORIZER_URLS", "url")
 }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -356,6 +356,47 @@ paths:
           $ref: '#/components/responses/400'
         502:
           $ref: '#/components/responses/502'
+  /publisher/{identifier}:
+    put:
+      x-amazon-apigateway-integration:
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${UpdatePublicationChannelFunction.Arn}/invocations
+        httpMethod: POST
+        type: "AWS_PROXY"
+      security:
+        - CognitoUserPool: [ 'https://api.nva.unit.no/scopes/backend', 'https://api.nva.unit.no/scopes/frontend' ]
+      requestBody:
+        required: true
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/UpdatePublisherRequest'
+      tags:
+        - Publisher
+      summary: Update publisher handler
+      description: Updates publisher
+      operationId: UpdatePublisher
+      parameters:
+        - name: identifier
+          in: path
+          description: identifier of publication channel to update
+          required: true
+          schema:
+            type: string
+          example: '151f411d-68cd-4c7a-9cbb-daf00e0326ce'
+      responses:
+        201:
+          description: Accepted
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        502:
+          $ref: '#/components/responses/502'
   /series:
     get:
       x-amazon-apigateway-integration:
@@ -552,11 +593,64 @@ paths:
           $ref: '#/components/responses/400'
         502:
           $ref: '#/components/responses/502'
+  /serial-publication/{identifier}:
+    put:
+      x-amazon-apigateway-integration:
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${UpdatePublicationChannelFunction.Arn}/invocations
+        httpMethod: POST
+        type: "AWS_PROXY"
+      security:
+        - CognitoUserPool: [ 'https://api.nva.unit.no/scopes/backend', 'https://api.nva.unit.no/scopes/frontend' ]
+      requestBody:
+        required: true
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/UpdateSerialPublicationRequest'
+      tags:
+        - SerialPublication
+      summary: Update serial publication
+      description: Updates serial publication
+      operationId: UpdateSerialPublication
+      parameters:
+        - name: identifier
+          in: path
+          description: identifier of publication channel to update
+          required: true
+          schema:
+            type: string
+          example: '151f411d-68cd-4c7a-9cbb-daf00e0326ce'
+      responses:
+        201:
+          description: Accepted
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        502:
+          $ref: '#/components/responses/502'
 
 components:
   responses:
     400:
       description: Bad Request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+    401:
+      description: Unauthorized
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+    403:
+      description: Forbidden
       content:
         application/problem+json:
           schema:
@@ -692,6 +786,46 @@ components:
           format: uri
           nullable: true
           description: The url to the publisher
+    UpdatePublisherRequest:
+      type: object
+      description: "Request to update a publisher channel."
+      properties:
+        type:
+          type: string
+          example: "UpdatePublisherRequest"
+        name:
+          type: string
+          description: "The name of the publisher."
+        isbn:
+          type: string
+          description: "The ISBN associated with the publisher."
+      required:
+        - type
+        - identifier
+        - name
+        - isbn
+    UpdateSerialPublicationRequest:
+      type: object
+      description: "Request to update a serial publication channel."
+      properties:
+        type:
+          type: string
+          example: "UpdateSerialPublicationRequest"
+        name:
+          type: string
+          description: "The name of the serial publication."
+        printIssn:
+          type: string
+          description: "The print ISSN associated with the serial publication."
+        onlineIssn:
+          type: string
+          description: "The online ISSN associated with the serial publication."
+      required:
+        - type
+        - identifier
+        - name
+        - printIssn
+        - onlineIssn
     SerialPublication:
       type: object
       properties:
@@ -916,3 +1050,13 @@ components:
         printIssn: '4321-4321'
         homepage: 'https://series-of-eternal.fury.no'
       summary: A sample create series
+  securitySchemes:
+    CognitoUserPool:
+      type: apiKey
+      name: Authorization
+      in: header
+      x-amazon-apigateway-authtype: cognito_user_pools
+      x-amazon-apigateway-authorizer:
+        type: cognito_user_pools
+        providerARNs:
+          - Ref: CognitoAuthorizerArn

--- a/src/main/java/no/sikt/nva/pubchannels/channelregistry/ChannelRegistryUpdateChannelRequest.java
+++ b/src/main/java/no/sikt/nva/pubchannels/channelregistry/ChannelRegistryUpdateChannelRequest.java
@@ -1,0 +1,8 @@
+package no.sikt.nva.pubchannels.channelregistry;
+
+import java.util.UUID;
+import no.unit.nva.commons.json.JsonSerializable;
+
+public record ChannelRegistryUpdateChannelRequest(
+    UUID pid, String name, String pissn, String eissn, String isbnPrefix, String type)
+    implements JsonSerializable {}

--- a/src/main/java/no/sikt/nva/pubchannels/channelregistry/UpdateChannelRequest.java
+++ b/src/main/java/no/sikt/nva/pubchannels/channelregistry/UpdateChannelRequest.java
@@ -1,0 +1,18 @@
+package no.sikt.nva.pubchannels.channelregistry;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import java.util.UUID;
+import no.unit.nva.commons.json.JsonSerializable;
+
+@JsonTypeInfo(use = Id.NAME, property = "type")
+@JsonSubTypes({
+  @JsonSubTypes.Type(UpdatePublisherRequest.class),
+  @JsonSubTypes.Type(UpdateSerialPublicationRequest.class),
+})
+public sealed interface UpdateChannelRequest extends JsonSerializable
+    permits UpdatePublisherRequest, UpdateSerialPublicationRequest {
+
+  ChannelRegistryUpdateChannelRequest toChannelRegistryUpdateRequest(UUID identifier);
+}

--- a/src/main/java/no/sikt/nva/pubchannels/channelregistry/UpdatePublisherRequest.java
+++ b/src/main/java/no/sikt/nva/pubchannels/channelregistry/UpdatePublisherRequest.java
@@ -1,0 +1,13 @@
+package no.sikt.nva.pubchannels.channelregistry;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.util.UUID;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+public record UpdatePublisherRequest(String name, String isbn) implements UpdateChannelRequest {
+
+  @Override
+  public ChannelRegistryUpdateChannelRequest toChannelRegistryUpdateRequest(UUID identifier) {
+    return new ChannelRegistryUpdateChannelRequest(identifier, name, null, null, isbn, "publisher");
+  }
+}

--- a/src/main/java/no/sikt/nva/pubchannels/channelregistry/UpdateSerialPublicationRequest.java
+++ b/src/main/java/no/sikt/nva/pubchannels/channelregistry/UpdateSerialPublicationRequest.java
@@ -1,0 +1,15 @@
+package no.sikt.nva.pubchannels.channelregistry;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.util.UUID;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+public record UpdateSerialPublicationRequest(String name, String printIssn, String onlineIssn)
+    implements UpdateChannelRequest {
+
+  @Override
+  public ChannelRegistryUpdateChannelRequest toChannelRegistryUpdateRequest(UUID identifier) {
+    return new ChannelRegistryUpdateChannelRequest(
+        identifier, name, printIssn, onlineIssn, null, "serial-publication");
+  }
+}

--- a/src/main/java/no/sikt/nva/pubchannels/handler/PublicationChannelClient.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/PublicationChannelClient.java
@@ -1,4 +1,6 @@
 package no.sikt.nva.pubchannels.handler;
 
 public interface PublicationChannelClient
-    extends PublicationChannelSearchCreateClient, PublicationChannelFetchClient {}
+    extends PublicationChannelSearchCreateClient,
+        PublicationChannelFetchClient,
+        PublicationChannelUpdateClient {}

--- a/src/main/java/no/sikt/nva/pubchannels/handler/PublicationChannelUpdateClient.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/PublicationChannelUpdateClient.java
@@ -1,0 +1,9 @@
+package no.sikt.nva.pubchannels.handler;
+
+import no.sikt.nva.pubchannels.channelregistry.ChannelRegistryUpdateChannelRequest;
+import nva.commons.apigateway.exceptions.ApiGatewayException;
+
+public interface PublicationChannelUpdateClient {
+
+  void updateChannel(ChannelRegistryUpdateChannelRequest request) throws ApiGatewayException;
+}

--- a/src/main/java/no/sikt/nva/pubchannels/handler/update/UpdatePublicationChannelHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/update/UpdatePublicationChannelHandler.java
@@ -1,0 +1,68 @@
+package no.sikt.nva.pubchannels.handler.update;
+
+import static java.net.HttpURLConnection.HTTP_ACCEPTED;
+import static nva.commons.core.attempt.Try.attempt;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import java.util.UUID;
+import no.sikt.nva.pubchannels.channelregistry.ChannelRegistryClient;
+import no.sikt.nva.pubchannels.channelregistry.UpdateChannelRequest;
+import no.sikt.nva.pubchannels.handler.PublicationChannelUpdateClient;
+import nva.commons.apigateway.AccessRight;
+import nva.commons.apigateway.ApiGatewayHandler;
+import nva.commons.apigateway.RequestInfo;
+import nva.commons.apigateway.exceptions.ApiGatewayException;
+import nva.commons.apigateway.exceptions.BadRequestException;
+import nva.commons.apigateway.exceptions.ForbiddenException;
+import nva.commons.apigateway.exceptions.UnauthorizedException;
+import nva.commons.core.Environment;
+import nva.commons.core.JacocoGenerated;
+
+public class UpdatePublicationChannelHandler extends ApiGatewayHandler<UpdateChannelRequest, Void> {
+
+  protected static final String IDENTIFIER = "identifier";
+  protected static final String IDENTIFIER_PARAMETER_IS_MISSING = "Identifier parameter is missing";
+  protected static final String INVALID_IDENTIFIER_MESSAGE = "Provided identifier is not valid UUID";
+  private final PublicationChannelUpdateClient client;
+
+  @JacocoGenerated
+  public UpdatePublicationChannelHandler() {
+    this(ChannelRegistryClient.defaultInstance());
+  }
+
+  public UpdatePublicationChannelHandler(PublicationChannelUpdateClient client) {
+    super(UpdateChannelRequest.class, new Environment());
+    this.client = client;
+  }
+
+  @Override
+  protected void validateRequest(
+      UpdateChannelRequest input, RequestInfo requestInfo, Context context)
+      throws ApiGatewayException {
+    if (!requestInfo.isGatewayAuthorized()) {
+      throw new UnauthorizedException();
+    }
+    if (!requestInfo.userIsAuthorized(AccessRight.MANAGE_CUSTOMERS)) {
+      throw new ForbiddenException();
+    }
+    if (!requestInfo.getPathParameters().containsKey(IDENTIFIER)) {
+      throw new BadRequestException(IDENTIFIER_PARAMETER_IS_MISSING);
+    }
+
+    attempt(() -> UUID.fromString(requestInfo.getPathParameter(IDENTIFIER)))
+        .orElseThrow(failure -> new BadRequestException(INVALID_IDENTIFIER_MESSAGE));
+  }
+
+  @Override
+  protected Void processInput(UpdateChannelRequest input, RequestInfo requestInfo, Context context)
+      throws ApiGatewayException {
+    var identifier = UUID.fromString(requestInfo.getPathParameter(IDENTIFIER));
+    client.updateChannel(input.toChannelRegistryUpdateRequest(identifier));
+    return null;
+  }
+
+  @Override
+  protected Integer getSuccessStatusCode(UpdateChannelRequest input, Void output) {
+    return HTTP_ACCEPTED;
+  }
+}

--- a/src/test/java/no/sikt/nva/pubchannels/channelregistry/ChannelRegistryClientTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/channelregistry/ChannelRegistryClientTest.java
@@ -1,0 +1,197 @@
+package no.sikt.nva.pubchannels.channelregistry;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.patch;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static java.net.HttpURLConnection.HTTP_BAD_GATEWAY;
+import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
+import static java.util.UUID.randomUUID;
+import static no.sikt.nva.pubchannels.HttpHeaders.ACCEPT;
+import static no.sikt.nva.pubchannels.HttpHeaders.CONTENT_TYPE;
+import static no.sikt.nva.pubchannels.HttpHeaders.CONTENT_TYPE_APPLICATION_JSON;
+import static no.sikt.nva.pubchannels.HttpHeaders.CONTENT_TYPE_APPLICATION_JSON_UTF8;
+import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static nva.commons.core.StringUtils.EMPTY_STRING;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import java.net.URI;
+import java.time.Year;
+import java.util.UUID;
+import no.sikt.nva.pubchannels.HttpHeaders;
+import no.sikt.nva.pubchannels.channelregistry.model.ChannelRegistryLevel;
+import no.sikt.nva.pubchannels.channelregistry.model.ChannelRegistryPublisher;
+import no.sikt.nva.pubchannels.dataporten.DataportenAuthClient;
+import no.sikt.nva.pubchannels.dataporten.model.TokenBodyResponse;
+import no.unit.nva.commons.json.JsonUtils;
+import no.unit.nva.stubs.WiremockHttpClient;
+import nva.commons.apigateway.exceptions.BadGatewayException;
+import nva.commons.apigateway.exceptions.BadRequestException;
+import nva.commons.apigateway.exceptions.NotFoundException;
+import nva.commons.apigateway.exceptions.UnauthorizedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@WireMockTest(httpsEnabled = true)
+class ChannelRegistryClientTest {
+
+  private ChannelRegistryClient client;
+
+  @BeforeEach
+  void setUp(WireMockRuntimeInfo runtimeInfo) {
+    var channelRegistryBaseUri = URI.create(runtimeInfo.getHttpsBaseUrl());
+    var httpClient = WiremockHttpClient.create();
+    var dataportenBaseUri = URI.create(runtimeInfo.getHttpsBaseUrl());
+    var authClient = new DataportenAuthClient(httpClient, dataportenBaseUri, "", "");
+    this.client = new ChannelRegistryClient(httpClient, channelRegistryBaseUri, authClient);
+  }
+
+  @Test
+  void shouldThrowUnauthorizedWhenAuthorizingFails() throws JsonProcessingException {
+    var channelIdentifier = randomUUID();
+    var request = createRequest(channelIdentifier, "publisher");
+
+    stubTokenResponse(HTTP_UNAUTHORIZED);
+
+    assertThrows(UnauthorizedException.class, () -> client.updateChannel(request));
+  }
+
+  @Test
+  void shouldThrowBadRequestWhenAttemptingToUpdateChannelWithUnsupportedType()
+      throws JsonProcessingException {
+    var channelIdentifier = randomUUID();
+    var request = createRequest(channelIdentifier, randomString());
+
+    stubTokenResponse(HTTP_OK);
+
+    assertThrows(BadRequestException.class, () -> client.updateChannel(request));
+  }
+
+  @Test
+  void shouldThrowNotFoundWhenUpdatingPublisherRespondsWith404WhenFetchingChannel()
+      throws JsonProcessingException {
+    var channelIdentifier = randomUUID();
+    var request = createRequest(channelIdentifier, "publisher");
+
+    stubTokenResponse(HTTP_OK);
+    stubFetchChannelResponse(channelIdentifier, HTTP_NOT_FOUND, EMPTY_STRING, "findpublisher");
+
+    assertThrows(NotFoundException.class, () -> client.updateChannel(request));
+  }
+
+  @Test
+  void shouldThrowNotFoundWhenUpdatingSerialPublicationRespondsWith404WhenFetchingChannel()
+      throws JsonProcessingException {
+    var channelIdentifier = randomUUID();
+    var request = createRequest(channelIdentifier, "serial-publication");
+
+    stubTokenResponse(HTTP_OK);
+    stubFetchChannelResponse(channelIdentifier, HTTP_NOT_FOUND, EMPTY_STRING, "findjournalserie");
+
+    assertThrows(NotFoundException.class, () -> client.updateChannel(request));
+  }
+
+  @Test
+  void shouldThrowBadRequestWhenUpdatingNotUnassignedChannel() throws JsonProcessingException {
+    var channelIdentifier = randomUUID();
+    var request = createRequest(channelIdentifier, "publisher");
+
+    stubTokenResponse(HTTP_OK);
+    stubFetchChannelResponse(
+        channelIdentifier, HTTP_OK, channelWithScientValue("1"), "findpublisher");
+
+    assertThrows(BadRequestException.class, () -> client.updateChannel(request));
+  }
+
+  @Test
+  void shouldThrowBadRequestWhenChannelRegistryRespondsWith4XXStatusCodeOnUpdate()
+      throws JsonProcessingException {
+    var channelIdentifier = randomUUID();
+    var request = createRequest(channelIdentifier, "publisher");
+
+    stubTokenResponse(HTTP_OK);
+    stubFetchChannelResponse(
+        channelIdentifier, HTTP_OK, channelWithScientValue(null), "findpublisher");
+    stubUpdateChannelResponse(HTTP_BAD_REQUEST);
+
+    assertThrows(BadRequestException.class, () -> client.updateChannel(request));
+  }
+
+  @Test
+  void shouldThrowBadGatewayWhenChannelRegistryRespondsWith5XXOnUpdate()
+      throws JsonProcessingException {
+    var channelIdentifier = randomUUID();
+    var request = createRequest(channelIdentifier, "publisher");
+
+    stubTokenResponse(HTTP_OK);
+    stubFetchChannelResponse(
+        channelIdentifier, HTTP_OK, channelWithScientValue(null), "findpublisher");
+    stubUpdateChannelResponse(HTTP_BAD_GATEWAY);
+
+    assertThrows(BadGatewayException.class, () -> client.updateChannel(request));
+  }
+
+  private static ChannelRegistryUpdateChannelRequest createRequest(
+      UUID channelIdentifier, String type) {
+    return new ChannelRegistryUpdateChannelRequest(channelIdentifier, null, null, null, null, type);
+  }
+
+  private static ChannelRegistryLevel randomLevel(String level) {
+    return new ChannelRegistryLevel(
+        Integer.parseInt(Year.now().toString()), level, level, randomString(), null);
+  }
+
+  private static void stubFetchChannelResponse(
+      UUID channelIdentifier, int statusCode, String body, String path) {
+    stubFor(
+        get(urlPathEqualTo(("/%s/%s/%s").formatted(path, channelIdentifier, Year.now().toString())))
+            .withHeader(ACCEPT, WireMock.equalTo(CONTENT_TYPE_APPLICATION_JSON))
+            .willReturn(
+                aResponse()
+                    .withStatus(statusCode)
+                    .withHeader(CONTENT_TYPE, CONTENT_TYPE_APPLICATION_JSON_UTF8)
+                    .withBody(body)));
+  }
+
+  private static void stubTokenResponse(int statusCode) throws JsonProcessingException {
+    stubFor(
+        post("/oauth/token")
+            .withBasicAuth(EMPTY_STRING, EMPTY_STRING)
+            .withHeader(
+                HttpHeaders.CONTENT_TYPE,
+                WireMock.equalTo(HttpHeaders.CONTENT_TYPE_X_WWW_FORM_URLENCODED))
+            .willReturn(
+                aResponse()
+                    .withStatus(statusCode)
+                    .withBody(
+                        dtoObjectMapper.writeValueAsString(
+                            new TokenBodyResponse("token1", "Bearer")))));
+  }
+
+  private String channelWithScientValue(String level) throws JsonProcessingException {
+    return JsonUtils.dtoObjectMapper.writeValueAsString(
+        new ChannelRegistryPublisher(
+            randomUUID().toString(), randomLevel(level), null, null, null, null, "publisher"));
+  }
+
+  private void stubUpdateChannelResponse(int statusCode) {
+    stubFor(
+        patch(urlPathEqualTo("/admin/change"))
+            .withHeader(ACCEPT, WireMock.equalTo(CONTENT_TYPE_APPLICATION_JSON))
+            .willReturn(
+                aResponse()
+                    .withStatus(statusCode)
+                    .withHeader(CONTENT_TYPE, CONTENT_TYPE_APPLICATION_JSON_UTF8)
+                    .withBody(EMPTY_STRING)));
+  }
+}

--- a/src/test/java/no/sikt/nva/pubchannels/channelregistry/UpdateChannelRequestTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/channelregistry/UpdateChannelRequestTest.java
@@ -1,0 +1,44 @@
+package no.sikt.nva.pubchannels.channelregistry;
+
+import static no.unit.nva.testutils.RandomDataGenerator.randomIsbn10;
+import static no.unit.nva.testutils.RandomDataGenerator.randomIssn;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class UpdateChannelRequestTest {
+
+  @Test
+  void shouldConvertUpdatePublisherRequestToChannelRegistryRequestCorrectly() {
+    var isbn = randomIsbn10();
+    var name = randomString();
+    var identifier = UUID.randomUUID();
+    var request = new UpdatePublisherRequest(name, isbn);
+
+    var channelRegistryRequest = request.toChannelRegistryUpdateRequest(identifier);
+
+    var expected =
+        new ChannelRegistryUpdateChannelRequest(identifier, name, null, null, isbn, "publisher");
+
+    assertEquals(expected, channelRegistryRequest);
+  }
+
+  @Test
+  void shouldConvertUpdateSerialPublicationRequestToChannelRegistryRequestCorrectly() {
+    var printIssn = randomIssn();
+    var onlineIssn = randomIssn();
+    var name = randomString();
+    var identifier = UUID.randomUUID();
+    var request = new UpdateSerialPublicationRequest(name, printIssn, onlineIssn);
+
+    var channelRegistryRequest = request.toChannelRegistryUpdateRequest(identifier);
+
+    var expected =
+        new ChannelRegistryUpdateChannelRequest(
+            identifier, name, printIssn, onlineIssn, null, "serial-publication");
+
+    assertEquals(expected, channelRegistryRequest);
+  }
+}

--- a/src/test/java/no/sikt/nva/pubchannels/handler/update/UpdatePublicationChannelHandlerTest.java
+++ b/src/test/java/no/sikt/nva/pubchannels/handler/update/UpdatePublicationChannelHandlerTest.java
@@ -1,0 +1,160 @@
+package no.sikt.nva.pubchannels.handler.update;
+
+import static java.net.HttpURLConnection.HTTP_ACCEPTED;
+import static java.net.HttpURLConnection.HTTP_BAD_GATEWAY;
+import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
+import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
+import static java.util.UUID.randomUUID;
+import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
+import static nva.commons.apigateway.AccessRight.MANAGE_CUSTOMERS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import no.sikt.nva.pubchannels.channelregistry.UpdateChannelRequest;
+import no.sikt.nva.pubchannels.channelregistry.UpdateSerialPublicationRequest;
+import no.sikt.nva.pubchannels.handler.PublicationChannelClient;
+import no.sikt.nva.pubchannels.handler.PublicationChannelUpdateClient;
+import no.unit.nva.stubs.FakeContext;
+import no.unit.nva.testutils.HandlerRequestBuilder;
+import nva.commons.apigateway.AccessRight;
+import nva.commons.apigateway.GatewayResponse;
+import nva.commons.apigateway.exceptions.ApiGatewayException;
+import nva.commons.apigateway.exceptions.BadGatewayException;
+import nva.commons.apigateway.exceptions.NotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.zalando.problem.Problem;
+
+class UpdatePublicationChannelHandlerTest {
+
+  protected static final FakeContext CONTEXT = new FakeContext();
+  private UpdatePublicationChannelHandler handler;
+  private PublicationChannelUpdateClient client;
+  private ByteArrayOutputStream output;
+
+  @BeforeEach
+  void setUp() {
+    this.output = new ByteArrayOutputStream();
+    this.client = mock(PublicationChannelClient.class);
+    this.handler = new UpdatePublicationChannelHandler(client);
+  }
+
+  @Test
+  void shouldReturnUnauthorizedWhenUserIsNotAuthorized() throws IOException {
+    var request = createUnauthorizedRequest();
+
+    handler.handleRequest(request, output, CONTEXT);
+
+    var response = GatewayResponse.fromOutputStream(output, Problem.class);
+
+    assertEquals(HTTP_UNAUTHORIZED, response.getStatusCode());
+  }
+
+  @Test
+  void shouldReturnForbiddenWhenUserHasNoManageCustomersAccessRight() throws IOException {
+    var request = createAuthorizedRequest();
+
+    handler.handleRequest(request, output, CONTEXT);
+
+    var response = GatewayResponse.fromOutputStream(output, Problem.class);
+
+    assertEquals(HTTP_FORBIDDEN, response.getStatusCode());
+  }
+
+  @Test
+  void shouldReturnBadRequestWhenIdentifierIsMissingInPathParam() throws IOException {
+    var request = createRequestWithoutPathParams();
+
+    handler.handleRequest(request, output, CONTEXT);
+
+    var response = GatewayResponse.fromOutputStream(output, Problem.class);
+
+    assertEquals(HTTP_BAD_REQUEST, response.getStatusCode());
+  }
+
+  @Test
+  void shouldReturnBadRequestWhenIdentifierInPathParamIsNotValidUUID() throws IOException {
+    var request = createRequest(randomString());
+
+    handler.handleRequest(request, output, CONTEXT);
+
+    var response = GatewayResponse.fromOutputStream(output, Problem.class);
+
+    assertEquals(HTTP_BAD_REQUEST, response.getStatusCode());
+  }
+
+  @Test
+  void shouldReturnNotFoundWhenAttemptingToUpdateNonExistingChannel()
+      throws IOException, ApiGatewayException {
+    var request = createRequest(randomUUID().toString());
+
+    doThrow(new NotFoundException(randomString())).when(client).updateChannel(any());
+
+    handler.handleRequest(request, output, CONTEXT);
+
+    var response = GatewayResponse.fromOutputStream(output, Problem.class);
+
+    assertEquals(HTTP_NOT_FOUND, response.getStatusCode());
+  }
+
+  @Test
+  void shouldReturnBadGatewayWhenUnexpectedErrorFromChannelRegistry()
+      throws IOException, ApiGatewayException {
+    var request = createRequest(randomUUID().toString());
+
+    doThrow(new BadGatewayException(randomString())).when(client).updateChannel(any());
+
+    handler.handleRequest(request, output, CONTEXT);
+
+    var response = GatewayResponse.fromOutputStream(output, Problem.class);
+
+    assertEquals(HTTP_BAD_GATEWAY, response.getStatusCode());
+  }
+
+  @Test
+  void shouldReturnAcceptedWhenSuccessfullyUpdatedChannel() throws IOException {
+    var request = createRequest(randomUUID().toString());
+
+    handler.handleRequest(request, output, CONTEXT);
+
+    var response = GatewayResponse.fromOutputStream(output, Problem.class);
+
+    assertEquals(HTTP_ACCEPTED, response.getStatusCode());
+  }
+
+  private InputStream createRequestWithoutPathParams() throws JsonProcessingException {
+    return new HandlerRequestBuilder<UpdateChannelRequest>(dtoObjectMapper)
+        .withAccessRights(randomUri(), MANAGE_CUSTOMERS)
+        .withBody(new UpdateSerialPublicationRequest(randomString(), null, null))
+        .build();
+  }
+
+  private InputStream createRequest(String identifier) throws JsonProcessingException {
+    return new HandlerRequestBuilder<UpdateChannelRequest>(dtoObjectMapper)
+        .withAccessRights(randomUri(), AccessRight.MANAGE_CUSTOMERS)
+        .withBody(new UpdateSerialPublicationRequest(randomString(), null, null))
+        .withPathParameters(Map.of("identifier", identifier))
+        .build();
+  }
+
+  private InputStream createAuthorizedRequest() throws JsonProcessingException {
+    return new HandlerRequestBuilder<UpdateChannelRequest>(dtoObjectMapper)
+        .withAccessRights(randomUri(), AccessRight.MANAGE_NVI)
+        .build();
+  }
+
+  private InputStream createUnauthorizedRequest() throws JsonProcessingException {
+    return new HandlerRequestBuilder<UpdateChannelRequest>(dtoObjectMapper).build();
+  }
+}

--- a/template.yaml
+++ b/template.yaml
@@ -422,6 +422,27 @@ Resources:
       Action: lambda:InvokeFunction
       Principal: 'apigateway.amazonaws.com'
 
+  UpdatePublicationChannelFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: no.sikt.nva.pubchannels.handler.update.UpdatePublicationChannelHandler::handleRequest
+      Policies:
+        - !GetAtt ReadSecretsPolicy.PolicyArn
+      Events:
+        CreateSeriesEvent:
+          Type: Api
+          Properties:
+            RestApiId: !Ref PublicationChannelsApi
+            Path: /{type}/{identifier}
+            Method: put
+
+  UpdatePublicationChannelFunctionPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt UpdatePublicationChannelFunction.Arn
+      Action: lambda:InvokeFunction
+      Principal: 'apigateway.amazonaws.com'
+
   DataportenChannelRegistryHealthCheck:
     Type: AWS::Route53::HealthCheck
     Properties:


### PR DESCRIPTION
Implementing `UpdatePublicationChannelHandler` and two new endpoints to update publisher and serial-publication.

Deciding to split it into two endpoints on api level in order to make api cleaner. 

`PUT: /publisher/{identifier}` will consume `UpdatePublisherRequest `
and
`PUT: /serial-publication/{identifier}` will consume `UpdateSerialPublicationRequest `

Otherwise api user should control that path param and request body is always matching, which is not necessary I think, maybe it is :)

Publisher:
![image](https://github.com/user-attachments/assets/ab7df92e-ef01-4889-872b-60fca8272a36)

Serial-publication:
![image](https://github.com/user-attachments/assets/cf952c2a-9397-400f-8885-57f7fa4bcdc2)
