### PR TITLE
fix: Add timeout handling

### DIFF
--- a/src/main/java/no/sikt/nva/pubchannels/channelregistrycache/ChannelRegistryCsvLoader.java
+++ b/src/main/java/no/sikt/nva/pubchannels/channelregistrycache/ChannelRegistryCsvLoader.java
@@ -95,8 +95,7 @@ public final class ChannelRegistryCsvLoader {
                   "%n".formatted(),
                   "",
                   "%n%nFailed to parse %d out of %d CSV lines"
-                      .formatted(failures.size(), totalLines)
-                  ));
+                      .formatted(failures.size(), totalLines)));
     } else {
       return "Successfully parsed all %s CSV lines".formatted(totalLines);
     }


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-50566

Sets a 20 second timeout on calls to Kanalregisteret so that we can gracefully handle timeouts and log an explanation. Given the 30 sec timeout on the lambda itself, this is hopefully sufficient.