### PR TITLE
fix: Set caching for all GET endpoints

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -30,11 +30,11 @@ paths:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${FetchPublicationChannelByIdentifierAndYearFunction.Arn}/invocations
         httpMethod: POST
         requestParameters:
-          integration.request.path.identifier:
-            'method.request.path.identifier'
-          integration.request.path.year:
-            'method.request.path.year'
+          integration.request.path.type: 'method.request.path.type'
+          integration.request.path.identifier: 'method.request.path.identifier'
+          integration.request.path.year: 'method.request.path.year'
         cacheKeyParameters:
+          - 'method.request.path.type'
           - 'method.request.path.identifier'
           - 'method.request.path.year'
         type: "AWS_PROXY"
@@ -106,10 +106,11 @@ paths:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${FetchPublicationChannelByIdentifierAndYearFunction.Arn}/invocations
         httpMethod: POST
         requestParameters:
-          integration.request.path.identifier:
-          - 'method.request.path.identifier'
+          integration.request.path.type: 'method.request.path.type'
+          integration.request.path.identifier: 'method.request.path.identifier'
         cacheKeyParameters:
-        - 'method.request.path.identifier'
+          - 'method.request.path.type'
+          - 'method.request.path.identifier'
         type: "AWS_PROXY"
       tags:
         - PublicationChannel

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -170,6 +170,16 @@ paths:
         uri:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SearchJournalByQueryFunction.Arn}/invocations
         httpMethod: POST
+        requestParameters:
+          integration.request.querystring.query: 'method.request.querystring.query'
+          integration.request.querystring.year: 'method.request.querystring.year'
+          integration.request.querystring.offset: 'method.request.querystring.offset'
+          integration.request.querystring.size: 'method.request.querystring.size'
+        cacheKeyParameters:
+          - 'method.request.querystring.query'
+          - 'method.request.querystring.year'
+          - 'method.request.querystring.offset'
+          - 'method.request.querystring.size'
         type: "AWS_PROXY"
       tags:
         - Journal
@@ -266,6 +276,16 @@ paths:
         uri:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SearchPublisherByQueryFunction.Arn}/invocations
         httpMethod: POST
+        requestParameters:
+          integration.request.querystring.query: 'method.request.querystring.query'
+          integration.request.querystring.year: 'method.request.querystring.year'
+          integration.request.querystring.offset: 'method.request.querystring.offset'
+          integration.request.querystring.size: 'method.request.querystring.size'
+        cacheKeyParameters:
+          - 'method.request.querystring.query'
+          - 'method.request.querystring.year'
+          - 'method.request.querystring.offset'
+          - 'method.request.querystring.size'
         type: "AWS_PROXY"
       tags:
         - Publisher
@@ -403,6 +423,16 @@ paths:
         uri:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SearchSeriesByQueryFunction.Arn}/invocations
         httpMethod: POST
+        requestParameters:
+          integration.request.querystring.query: 'method.request.querystring.query'
+          integration.request.querystring.year: 'method.request.querystring.year'
+          integration.request.querystring.offset: 'method.request.querystring.offset'
+          integration.request.querystring.size: 'method.request.querystring.size'
+        cacheKeyParameters:
+          - 'method.request.querystring.query'
+          - 'method.request.querystring.year'
+          - 'method.request.querystring.offset'
+          - 'method.request.querystring.size'
         type: "AWS_PROXY"
       tags:
         - Series
@@ -499,6 +529,16 @@ paths:
         uri:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SearchSerialPublicationByQueryFunction.Arn}/invocations
         httpMethod: POST
+        requestParameters:
+          integration.request.querystring.query: 'method.request.querystring.query'
+          integration.request.querystring.year: 'method.request.querystring.year'
+          integration.request.querystring.offset: 'method.request.querystring.offset'
+          integration.request.querystring.size: 'method.request.querystring.size'
+        cacheKeyParameters:
+          - 'method.request.querystring.query'
+          - 'method.request.querystring.year'
+          - 'method.request.querystring.offset'
+          - 'method.request.querystring.size'
         type: "AWS_PROXY"
       tags:
         - SerialPublication

--- a/src/main/java/no/sikt/nva/pubchannels/handler/fetch/FetchPublicationChannelHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/fetch/FetchPublicationChannelHandler.java
@@ -5,8 +5,10 @@ import static java.net.HttpURLConnection.HTTP_OK;
 import static nva.commons.apigateway.MediaTypes.APPLICATION_JSON_LD;
 
 import com.amazonaws.services.lambda.runtime.Context;
+import com.google.common.net.HttpHeaders;
 import com.google.common.net.MediaType;
 import java.util.List;
+import java.util.Map;
 import no.sikt.nva.pubchannels.channelregistry.ChannelRegistryClient;
 import no.sikt.nva.pubchannels.channelregistrycache.db.service.CacheService;
 import no.sikt.nva.pubchannels.handler.PublicationChannelFetchClient;
@@ -21,6 +23,7 @@ import nva.commons.core.JacocoGenerated;
 
 public class FetchPublicationChannelHandler extends ApiGatewayHandler<Void, PublicationChannelDto> {
 
+  private static final int CACHE_MAX_AGE_SECONDS = 300;
   private final PublicationChannelService publicationChannelService;
 
   @JacocoGenerated
@@ -57,6 +60,8 @@ public class FetchPublicationChannelHandler extends ApiGatewayHandler<Void, Publ
   @Override
   protected PublicationChannelDto processInput(Void input, RequestInfo requestInfo, Context context)
       throws ApiGatewayException {
+    addAdditionalHeaders(
+        () -> Map.of(HttpHeaders.CACHE_CONTROL, "max-age=" + CACHE_MAX_AGE_SECONDS));
     return publicationChannelService.fetch(RequestObject.fromRequestInfo(requestInfo));
   }
 

--- a/src/main/java/no/sikt/nva/pubchannels/handler/search/SearchByQueryHandler.java
+++ b/src/main/java/no/sikt/nva/pubchannels/handler/search/SearchByQueryHandler.java
@@ -1,8 +1,21 @@
 package no.sikt.nva.pubchannels.handler.search;
 
+import static com.google.common.net.MediaType.JSON_UTF_8;
+import static no.sikt.nva.pubchannels.handler.validator.Validator.validatePagination;
+import static no.sikt.nva.pubchannels.handler.validator.Validator.validateString;
+import static no.sikt.nva.pubchannels.handler.validator.Validator.validateYear;
+import static nva.commons.apigateway.MediaTypes.APPLICATION_JSON_LD;
+import static nva.commons.core.attempt.Try.attempt;
+import static nva.commons.core.paths.UriWrapper.HTTPS;
+
 import com.amazonaws.services.lambda.runtime.Context;
 import com.google.common.net.HttpHeaders;
 import com.google.common.net.MediaType;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import no.sikt.nva.pubchannels.channelregistry.ChannelRegistryClient;
 import no.sikt.nva.pubchannels.channelregistry.ChannelType;
 import no.sikt.nva.pubchannels.handler.PublicationChannelClient;
@@ -16,20 +29,6 @@ import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.paths.UriWrapper;
 import org.apache.commons.validator.routines.ISSNValidator;
-
-import java.net.HttpURLConnection;
-import java.net.URI;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static com.google.common.net.MediaType.JSON_UTF_8;
-import static no.sikt.nva.pubchannels.handler.validator.Validator.validatePagination;
-import static no.sikt.nva.pubchannels.handler.validator.Validator.validateString;
-import static no.sikt.nva.pubchannels.handler.validator.Validator.validateYear;
-import static nva.commons.apigateway.MediaTypes.APPLICATION_JSON_LD;
-import static nva.commons.core.attempt.Try.attempt;
-import static nva.commons.core.paths.UriWrapper.HTTPS;
 
 public abstract class SearchByQueryHandler<T>
     extends ApiGatewayHandler<Void, PaginatedSearchResult<T>> {
@@ -91,7 +90,7 @@ public abstract class SearchByQueryHandler<T>
     }
 
     addAdditionalHeaders(
-      () -> Map.of(HttpHeaders.CACHE_CONTROL, "max-age=" + CACHE_MAX_AGE_SECONDS));
+        () -> Map.of(HttpHeaders.CACHE_CONTROL, "max-age=" + CACHE_MAX_AGE_SECONDS));
 
     return PaginatedSearchResult.create(
         constructBaseUri(),

--- a/template.yaml
+++ b/template.yaml
@@ -89,28 +89,32 @@ Resources:
       MethodSettings:
         - HttpMethod: 'GET'
           ResourcePath: '/~1journal~1{identifier}~1{year}'
-          CacheTtlInSeconds: 3600
+          CacheTtlInSeconds: 300
           CachingEnabled: true
         - HttpMethod: 'GET'
           ResourcePath: '/~1series~1{identifier}~1{year}'
-          CacheTtlInSeconds: 3600
+          CacheTtlInSeconds: 300
           CachingEnabled: true
         - HttpMethod: 'GET'
           ResourcePath: '/~1publisher~1{identifier}~1{year}'
-          CacheTtlInSeconds: 3600
+          CacheTtlInSeconds: 300
           CachingEnabled: true
         - HttpMethod: 'GET'
           ResourcePath: '/~1journal'
           CacheTtlInSeconds: 300
-          CachingEnabled: false
+          CachingEnabled: true
         - HttpMethod: 'GET'
           ResourcePath: '/~1series'
           CacheTtlInSeconds: 300
-          CachingEnabled: false
+          CachingEnabled: true
         - HttpMethod: 'GET'
           ResourcePath: '/~1publisher'
           CacheTtlInSeconds: 300
-          CachingEnabled: false
+          CachingEnabled: true
+        - HttpMethod: 'GET'
+          ResourcePath: '/~1serial-publication'
+          CacheTtlInSeconds: 300
+          CachingEnabled: true
       DefinitionBody:
         'Fn::Transform':
           Name: AWS::Include

--- a/template.yaml
+++ b/template.yaml
@@ -88,15 +88,11 @@ Resources:
       CacheClusterSize: "0.5"
       MethodSettings:
         - HttpMethod: 'GET'
-          ResourcePath: '/~1journal~1{identifier}~1{year}'
+          ResourcePath: '/~1{type}~1{identifier}~1{year}'
           CacheTtlInSeconds: 300
           CachingEnabled: true
         - HttpMethod: 'GET'
-          ResourcePath: '/~1series~1{identifier}~1{year}'
-          CacheTtlInSeconds: 300
-          CachingEnabled: true
-        - HttpMethod: 'GET'
-          ResourcePath: '/~1publisher~1{identifier}~1{year}'
+          ResourcePath: '/~1{type}~1{identifier}'
           CacheTtlInSeconds: 300
           CachingEnabled: true
         - HttpMethod: 'GET'


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-50579

Enables caching via ApiGateway and sets a default 300 second TTL for all endpoints. Note that this does not include a cache invalidation mechanism, so any updates to data may take up to 5 minutes to be visible to users.

## Summary of changes

  `template.yaml`:

  - Enabled caching for all GET search endpoints (/journal, /series, /publisher, /serial-publication)
  - Replaced specific fetch paths with generic /{type}/{identifier}/{year} and /{type}/{identifier} patterns
  - All endpoints use 300s TTL

  `docs/openapi.yaml`:

  - Added cacheKeyParameters to all 4 search endpoints (query, year, offset, size)
  - Fixed fetch endpoints to include type in cache key (was missing - would have caused cross-type cache collisions)

  `SearchByQueryHandler` and `FetchPublicationChannelHandler`:

  - Added Cache-Control: max-age=300 header for CloudFront caching

  ### Cached GET endpoints

  | Endpoint                    | Cache Key Parameters      |
  |-----------------------------|---------------------------|
  | /{type}/{identifier}/{year} | type, identifier, year    |
  | /{type}/{identifier}        | type, identifier          |
  | /journal                    | query, year, offset, size |
  | /series                     | query, year, offset, size |
  | /publisher                  | query, year, offset, size |
  | /serial-publication         | query, year, offset, size |