### PR TITLE
feat(handler): allow backend M2M tokens on create and update endpoints

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -242,6 +242,8 @@ paths:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${CreateJournalFunction.Arn}/invocations
         httpMethod: POST
         type: "AWS_PROXY"
+      security:
+        - CognitoUserPool: ["https://api.nva.unit.no/scopes/backend", "https://api.nva.unit.no/scopes/frontend"]
       tags:
         - Journal
       summary: Create journal
@@ -348,6 +350,8 @@ paths:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${CreatePublisherFunction.Arn}/invocations
         httpMethod: POST
         type: "AWS_PROXY"
+      security:
+        - CognitoUserPool: ["https://api.nva.unit.no/scopes/backend", "https://api.nva.unit.no/scopes/frontend"]
       tags:
         - Publisher
       summary: Create publisher
@@ -495,6 +499,8 @@ paths:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${CreateSeriesFunction.Arn}/invocations
         httpMethod: POST
         type: "AWS_PROXY"
+      security:
+        - CognitoUserPool: ["https://api.nva.unit.no/scopes/backend", "https://api.nva.unit.no/scopes/frontend"]
       tags:
         - Series
       summary: Create series
@@ -605,6 +611,8 @@ paths:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${CreateSerialPublicationFunction.Arn}/invocations
         httpMethod: POST
         type: "AWS_PROXY"
+      security:
+        - CognitoUserPool: ["https://api.nva.unit.no/scopes/backend", "https://api.nva.unit.no/scopes/frontend"]
       tags:
         - SerialPublication
       summary: Create series/journal

--- a/publication-channels/src/main/java/no/sikt/nva/pubchannels/handler/create/CreateHandler.java
+++ b/publication-channels/src/main/java/no/sikt/nva/pubchannels/handler/create/CreateHandler.java
@@ -54,6 +54,9 @@ public abstract class CreateHandler<I, O> extends ApiGatewayHandler<I, O> {
   }
 
   protected void userIsAuthorizedToCreate(RequestInfo requestInfo) throws UnauthorizedException {
+    if (requestInfo.clientIsInternalBackend()) {
+      return;
+    }
     if (isNull(requestInfo.getCurrentCustomer())) {
       throw new UnauthorizedException();
     }

--- a/publication-channels/src/main/java/no/sikt/nva/pubchannels/handler/update/UpdatePublicationChannelHandler.java
+++ b/publication-channels/src/main/java/no/sikt/nva/pubchannels/handler/update/UpdatePublicationChannelHandler.java
@@ -44,7 +44,7 @@ public class UpdatePublicationChannelHandler extends ApiGatewayHandler<UpdateCha
     if (!requestInfo.isGatewayAuthorized()) {
       throw new UnauthorizedException();
     }
-    if (!requestInfo.userIsAuthorized(AccessRight.MANAGE_CUSTOMERS)) {
+    if (!isAuthorizedToUpdate(requestInfo)) {
       throw new ForbiddenException();
     }
     if (!requestInfo.getPathParameters().containsKey(IDENTIFIER)) {
@@ -70,5 +70,10 @@ public class UpdatePublicationChannelHandler extends ApiGatewayHandler<UpdateCha
   @Override
   protected Integer getSuccessStatusCode(UpdateChannelRequest input, Void output) {
     return HTTP_ACCEPTED;
+  }
+
+  private static boolean isAuthorizedToUpdate(RequestInfo requestInfo) {
+    return requestInfo.clientIsInternalBackend()
+        || requestInfo.userIsAuthorized(AccessRight.MANAGE_CUSTOMERS);
   }
 }

--- a/publication-channels/src/test/java/no/sikt/nva/pubchannels/handler/create/BaseCreateSerialPublicationHandlerTest.java
+++ b/publication-channels/src/test/java/no/sikt/nva/pubchannels/handler/create/BaseCreateSerialPublicationHandlerTest.java
@@ -86,6 +86,29 @@ public abstract class BaseCreateSerialPublicationHandlerTest extends CreateHandl
   }
 
   @Test
+  void shouldAllowBackendClientWithoutCurrentCustomerToCreateChannel() throws IOException {
+    var expectedPid = UUID.randomUUID().toString();
+
+    var channelRegistryRequest =
+        new ChannelRegistryCreateSerialPublicationRequest(VALID_NAME, null, null, null);
+    stubPostResponse(
+        expectedPid,
+        channelRegistryRequest,
+        HttpURLConnection.HTTP_CREATED,
+        channelRegistryCreatePathElement);
+
+    var testChannel =
+        createEmptyTestChannel(currentYearAsInteger(), expectedPid, type).withName(VALID_NAME);
+    stubFetchOKResponse(testChannel, channelRegistryFetchPathElement);
+
+    var requestBody = requestBuilderWithRequiredFields().build();
+    handlerUnderTest.handleRequest(constructBackendRequest(requestBody), output, context);
+
+    var response = GatewayResponse.fromOutputStream(output, SerialPublicationDto.class);
+    assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_CREATED)));
+  }
+
+  @Test
   void shouldReturnBadGatewayWhenUnauthorized() throws IOException {
     var input = constructRequest(requestBuilderWithRequiredFields().build());
     var request = new ChannelRegistryCreateSerialPublicationRequest(VALID_NAME, null, null, null);

--- a/publication-channels/src/test/java/no/sikt/nva/pubchannels/handler/create/CreateHandlerTest.java
+++ b/publication-channels/src/test/java/no/sikt/nva/pubchannels/handler/create/CreateHandlerTest.java
@@ -46,6 +46,7 @@ public abstract class CreateHandlerTest {
   protected static final String USERNAME = "";
   protected static final String VALID_NAME = "Valid Name";
   protected static final String PROBLEM = "Some problem";
+  protected static final String BACKEND_SCOPE = "https://api.nva.unit.no/scopes/backend";
   protected static final Context context = new FakeContext();
   private static final TokenBodyResponse TOKEN_BODY = new TokenBodyResponse("token1", "Bearer");
   protected static Environment environment;
@@ -121,6 +122,13 @@ public abstract class CreateHandlerTest {
   protected static <T> InputStream constructUnauthorizedRequest(T body)
       throws JsonProcessingException {
     return new HandlerRequestBuilder<T>(dtoObjectMapper).withBody(body).build();
+  }
+
+  protected static <T> InputStream constructBackendRequest(T body) throws JsonProcessingException {
+    return new HandlerRequestBuilder<T>(dtoObjectMapper)
+        .withScope(BACKEND_SCOPE)
+        .withBody(body)
+        .build();
   }
 
   protected static void stubGetResponse(int statusCode, String url, String body) {

--- a/publication-channels/src/test/java/no/sikt/nva/pubchannels/handler/create/publisher/CreatePublisherHandlerTest.java
+++ b/publication-channels/src/test/java/no/sikt/nva/pubchannels/handler/create/publisher/CreatePublisherHandlerTest.java
@@ -295,6 +295,21 @@ class CreatePublisherHandlerTest extends CreateHandlerTest {
     assertThat(problem.getDetail(), is(containsString("Unauthorized")));
   }
 
+  @Test
+  void shouldAllowBackendClientWithoutCurrentCustomerToCreatePublisher() throws IOException {
+    var expectedPid = UUID.randomUUID().toString();
+    var request = new ChannelRegistryCreatePublisherRequest(VALID_NAME, null, null);
+    var requestBody = new CreatePublisherRequestBuilder().withName(VALID_NAME).build();
+
+    setupStub(expectedPid, request, HttpURLConnection.HTTP_CREATED);
+
+    handlerUnderTest.handleRequest(constructBackendRequest(requestBody), output, context);
+
+    var response = GatewayResponse.fromOutputStream(output, CreatePublisherResponse.class);
+
+    assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_CREATED)));
+  }
+
   private static Stream<String> invalidIsbnPrefixes() {
     return Stream.of("12345678912345", "978-12345-1234567", "String-String", "mWhEbgV6GfS6CQRWW");
   }

--- a/publication-channels/src/test/java/no/sikt/nva/pubchannels/handler/update/UpdatePublicationChannelHandlerTest.java
+++ b/publication-channels/src/test/java/no/sikt/nva/pubchannels/handler/update/UpdatePublicationChannelHandlerTest.java
@@ -142,7 +142,7 @@ class UpdatePublicationChannelHandlerTest {
 
     handler.handleRequest(request, output, CONTEXT);
 
-    var response = GatewayResponse.fromOutputStream(output, Problem.class);
+    var response = GatewayResponse.fromOutputStream(output, Void.class);
 
     assertEquals(HTTP_ACCEPTED, response.getStatusCode());
   }
@@ -153,7 +153,7 @@ class UpdatePublicationChannelHandlerTest {
 
     handler.handleRequest(request, output, CONTEXT);
 
-    var response = GatewayResponse.fromOutputStream(output, Problem.class);
+    var response = GatewayResponse.fromOutputStream(output, Void.class);
 
     assertEquals(HTTP_ACCEPTED, response.getStatusCode());
   }

--- a/publication-channels/src/test/java/no/sikt/nva/pubchannels/handler/update/UpdatePublicationChannelHandlerTest.java
+++ b/publication-channels/src/test/java/no/sikt/nva/pubchannels/handler/update/UpdatePublicationChannelHandlerTest.java
@@ -41,6 +41,7 @@ class UpdatePublicationChannelHandlerTest {
 
   protected static final FakeContext CONTEXT = new FakeContext();
   protected static final String IDENTIFIER = "identifier";
+  private static final String BACKEND_SCOPE = "https://api.nva.unit.no/scopes/backend";
   private UpdatePublicationChannelHandler handler;
   private PublicationChannelUpdateClient client;
   private ByteArrayOutputStream output;
@@ -146,6 +147,17 @@ class UpdatePublicationChannelHandlerTest {
     assertEquals(HTTP_ACCEPTED, response.getStatusCode());
   }
 
+  @Test
+  void shouldReturnAcceptedWhenBackendClientWithoutManageCustomersAccessRight() throws IOException {
+    var request = createBackendRequest(randomUUID().toString(), validRequestBody());
+
+    handler.handleRequest(request, output, CONTEXT);
+
+    var response = GatewayResponse.fromOutputStream(output, Problem.class);
+
+    assertEquals(HTTP_ACCEPTED, response.getStatusCode());
+  }
+
   private static UpdateSerialPublicationRequest validRequestBody() {
     return new UpdateSerialPublicationRequest(randomString(), null, null);
   }
@@ -161,6 +173,15 @@ class UpdatePublicationChannelHandlerTest {
       throws JsonProcessingException {
     return new HandlerRequestBuilder<UpdateChannelRequest>(dtoObjectMapper)
         .withAccessRights(randomUri(), AccessRight.MANAGE_CUSTOMERS)
+        .withBody(body)
+        .withPathParameters(Map.of(IDENTIFIER, identifier))
+        .build();
+  }
+
+  private InputStream createBackendRequest(String identifier, UpdateChannelRequest body)
+      throws JsonProcessingException {
+    return new HandlerRequestBuilder<UpdateChannelRequest>(dtoObjectMapper)
+        .withScope(BACKEND_SCOPE)
         .withBody(body)
         .withPathParameters(Map.of(IDENTIFIER, identifier))
         .build();


### PR DESCRIPTION
## Summary

Allows backend (M2M) tokens with the `https://api.nva.unit.no/scopes/backend` scope to call the create (POST) and update (PUT) endpoints, in addition to the existing user-token paths. This unblocks support/admin tooling without weakening existing access control.

- `CreateHandler.userIsAuthorizedToCreate` short-circuits when `requestInfo.clientIsInternalBackend()` is true; the existing `currentCustomer` check still runs for user tokens
- `UpdatePublicationChannelHandler.validateRequest` now extracts `isAuthorizedToUpdate(...)` returning true for either backend client or a user with `MANAGE_CUSTOMERS`
- POST endpoints in `docs/openapi.yaml` (`CreateJournal`, `CreatePublisher`, `CreateSeries`, `CreateSerialPublication`) now declare `CognitoUserPool` security with both `scopes/backend` and `scopes/frontend` — PUT endpoints already had this
- Tests cover the new backend-scoped success paths; existing user-token tests are kept intact

https://sikt.atlassian.net/browse/NP-51227