### PR TITLE
fix(template): move delete endpoint to /channel/{identifier} to avoid path conflict #NP-51227

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -675,7 +675,7 @@ paths:
           $ref: "#/components/responses/404"
         "502":
           $ref: "#/components/responses/502"
-  /{identifier}:
+  /channel/{identifier}:
     delete:
       x-amazon-apigateway-integration:
         uri:

--- a/template.yaml
+++ b/template.yaml
@@ -456,7 +456,7 @@ Resources:
           Type: Api
           Properties:
             RestApiId: !Ref PublicationChannelsApi
-            Path: /{identifier}
+            Path: /channel/{identifier}
             Method: delete
 
   DeletePublicationChannelFunctionPermission:


### PR DESCRIPTION
Fixes the failing deploy caused by an API Gateway path conflict introduced in the backend-only delete endpoint.

- The delete endpoint was mapped to `/{identifier}` directly under the API root, which clashed with the existing `/{type}` variable path part (API Gateway allows only one variable path part per parent resource), causing `PublicationChannelsApi` to enter `UPDATE_FAILED`.
- Moved the endpoint to `/channel/{identifier}` so the `{identifier}` variable now sits under the static `/channel` segment instead of being a sibling of `/{type}` at the root.
- Updated both `template.yaml` and `docs/openapi.yaml`. The handler is unchanged — it reads the `identifier` path parameter by name.

https://sikt.atlassian.net/browse/NP-51227
