### PR TITLE
fix(template): restore Lambda invoke permission for fetch without year

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -237,6 +237,12 @@ Resources:
             RestApiId: !Ref PublicationChannelsApi
             Path: /{type}/{identifier}/{year}
             Method: get
+        FetchPublisherByIdentifierEvent:
+          Type: Api
+          Properties:
+            RestApiId: !Ref PublicationChannelsApi
+            Path: /{type}/{identifier}
+            Method: get
       Environment:
         Variables:
           TABLE_NAME: !Ref ChannelRegisterCacheTable


### PR DESCRIPTION
SAM auto-generates `AWS::Lambda::Permission` with a `SourceArn` that matches only paths declared in the function's `Events:` block. The fetch-without-year route `/{type}/{identifier}` lives only in `openapi.yaml`, so when #128 removed the explicit `FetchPublicationChannelByIdentifierAndYearFunctionPermission` (which had no `SourceArn` and thus allowed any path), API Gateway lost permission to invoke the Fetch Lambda for that route — calls like `GET /serial-publication/{id}` returned 500/502.

- Add a second `Api` event `FetchPublisherByIdentifierEvent` for `Path: /{type}/{identifier}, Method: get` on `FetchPublicationChannelByIdentifierAndYearFunction`
- SAM will now generate a permission with `SourceArn: .../*/GET/*/*` in addition to the existing 3-segment one
- No handler changes needed — `RequestObject.fromRequestInfo` already handles missing year

https://sikt.atlassian.net/browse/NP-51227